### PR TITLE
feat: complete type validation integration (task-010)

### DIFF
--- a/manifests/task-009-snapshot-manifest_validator.manifest.json
+++ b/manifests/task-009-snapshot-manifest_validator.manifest.json
@@ -1,0 +1,1238 @@
+{
+  "goal": "Snapshot of existing code in validators/manifest_validator.py",
+  "taskType": "snapshot",
+  "supersedes": [
+    "manifests/task-001-add-schema-validation.manifest.json",
+    "manifests/task-002-add-ast-alignment-validation.manifest.json",
+    "manifests/task-003-behavioral-validation.manifest.json",
+    "manifests/task-005-type-validation.manifest.json",
+    "manifests/task-006-artifact-kind-metadata.manifest.json",
+    "manifests/task-006a-validator-module-attributes.manifest.json"
+  ],
+  "creatableFiles": [],
+  "editableFiles": [
+    "validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [],
+  "expectedArtifacts": {
+    "file": "validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "class",
+        "name": "AlignmentError",
+        "bases": [
+          "Exception"
+        ]
+      },
+      {
+        "type": "class",
+        "name": "_ArtifactCollector",
+        "bases": [
+          "ast.NodeVisitor"
+        ]
+      },
+      {
+        "type": "function",
+        "name": "validate_schema",
+        "parameters": [
+          {
+            "name": "manifest_data"
+          },
+          {
+            "name": "schema_path"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "extract_type_annotation",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "ast.AST"
+          },
+          {
+            "name": "annotation_attr",
+            "type": "str"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_extraction_inputs",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "Any"
+          },
+          {
+            "name": "annotation_attr",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_ast_to_type_string",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "Optional[ast.AST]"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_safe_ast_conversion",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "ast.AST"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_handle_subscript_node",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "ast.Subscript"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_handle_attribute_node",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "ast.Attribute"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_handle_union_operator",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "ast.BinOp"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_fallback_ast_unparse",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "ast.AST"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_safe_str_conversion",
+        "parameters": [
+          {
+            "name": "node",
+            "type": "Any"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "compare_types",
+        "parameters": [
+          {
+            "name": "manifest_type",
+            "type": "str"
+          },
+          {
+            "name": "implementation_type",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_type_input",
+        "parameters": [
+          {
+            "name": "type_value",
+            "type": "Any"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "normalize_type_string",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_modern_union_syntax",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_optional_type",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_is_optional_type",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_extract_bracketed_content",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          },
+          {
+            "name": "prefix",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_union_type",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_is_union_type",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_split_type_arguments",
+        "parameters": [
+          {
+            "name": "inner",
+            "type": "str"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_split_by_delimiter",
+        "parameters": [
+          {
+            "name": "text",
+            "type": "str"
+          },
+          {
+            "name": "delimiter",
+            "type": "str"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_comma_spacing",
+        "parameters": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_skip_spaces",
+        "parameters": [
+          {
+            "name": "text",
+            "type": "str"
+          },
+          {
+            "name": "start_idx",
+            "type": "int"
+          }
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "discover_related_manifests",
+        "parameters": [
+          {
+            "name": "target_file"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_get_task_number",
+        "parameters": [
+          {
+            "name": "path"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_merge_expected_artifacts",
+        "parameters": [
+          {
+            "name": "manifest_paths"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "validate_with_ast",
+        "parameters": [
+          {
+            "name": "manifest_data"
+          },
+          {
+            "name": "test_file_path"
+          },
+          {
+            "name": "use_manifest_chain"
+          },
+          {
+            "name": "validation_mode"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_parse_file",
+        "parameters": [
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "ast.AST"
+      },
+      {
+        "type": "function",
+        "name": "_collect_artifacts_from_ast",
+        "parameters": [
+          {
+            "name": "tree",
+            "type": "ast.AST"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_get_expected_artifacts",
+        "parameters": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          },
+          {
+            "name": "test_file_path",
+            "type": "str"
+          },
+          {
+            "name": "use_manifest_chain",
+            "type": "bool"
+          }
+        ],
+        "returns": "List[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_all_artifacts",
+        "parameters": [
+          {
+            "name": "expected_items",
+            "type": "List[dict]"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_check_unexpected_artifacts",
+        "parameters": [
+          {
+            "name": "expected_items",
+            "type": "List[dict]"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_single_artifact",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_artifact",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_behavioral",
+        "parameters": [
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_parameters_used",
+        "parameters": [
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_implementation",
+        "parameters": [
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_method_parameters",
+        "parameters": [
+          {
+            "name": "method_name",
+            "type": "str"
+          },
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "class_name",
+            "type": "str"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_class",
+        "parameters": [
+          {
+            "name": "class_name"
+          },
+          {
+            "name": "expected_bases"
+          },
+          {
+            "name": "found_classes"
+          },
+          {
+            "name": "found_class_bases"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_validate_attribute",
+        "parameters": [
+          {
+            "name": "attribute_name"
+          },
+          {
+            "name": "parent_class"
+          },
+          {
+            "name": "found_attributes"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_validate_function",
+        "parameters": [
+          {
+            "name": "function_name"
+          },
+          {
+            "name": "expected_parameters"
+          },
+          {
+            "name": "found_functions"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_validate_no_unexpected_artifacts",
+        "parameters": [
+          {
+            "name": "expected_items"
+          },
+          {
+            "name": "found_classes"
+          },
+          {
+            "name": "found_functions"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "validate_type_hints",
+        "parameters": [
+          {
+            "name": "manifest_artifacts",
+            "type": "dict"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_are_valid_type_validation_inputs",
+        "parameters": [
+          {
+            "name": "manifest_artifacts",
+            "type": "Any"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "Any"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_should_validate_artifact_types",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "Any"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_types",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_get_implementation_info",
+        "parameters": [
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_method_info",
+        "parameters": [
+          {
+            "name": "method_name",
+            "type": "str"
+          },
+          {
+            "name": "class_name",
+            "type": "str"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_function_info",
+        "parameters": [
+          {
+            "name": "function_name",
+            "type": "str"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_parameter_types",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "impl_info",
+            "type": "dict"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "str"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_validate_single_parameter",
+        "parameters": [
+          {
+            "name": "param_name",
+            "type": "str"
+          },
+          {
+            "name": "manifest_type",
+            "type": "str"
+          },
+          {
+            "name": "impl_params_dict",
+            "type": "dict"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_return_type",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "impl_info",
+            "type": "dict"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_is_typeddict_class",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_is_typeddict_base",
+        "parameters": [
+          {
+            "name": "base_name",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "should_skip_behavioral_validation",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "Any"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_should_skip_by_artifact_kind",
+        "parameters": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[bool]"
+      },
+      {
+        "type": "function",
+        "name": "__init__",
+        "parameters": [
+          {
+            "name": "validation_mode"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_Import",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_ImportFrom",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_is_local_import",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_is_class_name",
+        "parameters": [
+          {
+            "name": "name"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_FunctionDef",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_extract_parameter_types",
+        "parameters": [
+          {
+            "name": "args"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_store_function_info",
+        "parameters": [
+          {
+            "name": "name"
+          },
+          {
+            "name": "param_names"
+          },
+          {
+            "name": "param_types"
+          },
+          {
+            "name": "return_type"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_store_method_info",
+        "parameters": [
+          {
+            "name": "name"
+          },
+          {
+            "name": "param_names"
+          },
+          {
+            "name": "param_types"
+          },
+          {
+            "name": "return_type"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_ClassDef",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_Assign",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_process_class_assignments",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_process_module_assignments",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_process_tuple_assignment",
+        "parameters": [
+          {
+            "name": "target"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_track_class_instantiations",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_is_self_attribute",
+        "parameters": [
+          {
+            "name": "target"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_add_class_attribute",
+        "parameters": [
+          {
+            "name": "class_name"
+          },
+          {
+            "name": "attribute_name"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_add_module_attribute",
+        "parameters": [
+          {
+            "name": "attribute_name"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_AnnAssign",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_is_module_scope",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_Attribute",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "visit_Call",
+        "parameters": [
+          {
+            "name": "node"
+          }
+        ],
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "_OPTIONAL_PREFIX"
+      },
+      {
+        "type": "attribute",
+        "name": "_UNION_PREFIX"
+      },
+      {
+        "type": "attribute",
+        "name": "_BRACKET_OPEN"
+      },
+      {
+        "type": "attribute",
+        "name": "_BRACKET_CLOSE"
+      },
+      {
+        "type": "attribute",
+        "name": "_COMMA"
+      },
+      {
+        "type": "attribute",
+        "name": "_PIPE"
+      },
+      {
+        "type": "attribute",
+        "name": "_SPACE"
+      },
+      {
+        "type": "attribute",
+        "name": "_NONE_TYPE"
+      },
+      {
+        "type": "attribute",
+        "name": "_ARTIFACT_KIND_TYPE"
+      },
+      {
+        "type": "attribute",
+        "name": "_ARTIFACT_KIND_RUNTIME"
+      },
+      {
+        "type": "attribute",
+        "name": "_TYPEDDICT_INDICATOR"
+      },
+      {
+        "type": "attribute",
+        "name": "_ARTIFACT_TYPE_CLASS"
+      },
+      {
+        "type": "attribute",
+        "name": "_ARTIFACT_TYPE_FUNCTION"
+      },
+      {
+        "type": "attribute",
+        "name": "_ARTIFACT_TYPE_ATTRIBUTE"
+      },
+      {
+        "type": "attribute",
+        "name": "_VALIDATION_MODE_BEHAVIORAL"
+      },
+      {
+        "type": "attribute",
+        "name": "_VALIDATION_MODE_IMPLEMENTATION"
+      },
+      {
+        "type": "attribute",
+        "name": "validation_mode",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_classes",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_class_bases",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_attributes",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "variable_to_class",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_functions",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_methods",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "current_class",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "current_function",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_function_types",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "found_method_types",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "used_classes",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "used_functions",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "used_methods",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "used_arguments",
+        "class": "_ArtifactCollector"
+      },
+      {
+        "type": "attribute",
+        "name": "imports_pytest",
+        "class": "_ArtifactCollector"
+      }
+    ]
+  },
+  "validationCommand": []
+}

--- a/manifests/task-010-integrate-type-validation.manifest.json
+++ b/manifests/task-010-integrate-type-validation.manifest.json
@@ -1,0 +1,32 @@
+{
+  "goal": "Integrate type hint validation into main validation workflow to detect type mismatches during manifest validation",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_010_type_validation_integration.py"
+  ],
+  "expectedArtifacts": {
+    "file": "validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "validate_with_ast",
+        "parameters": [
+          {"name": "manifest_data"},
+          {"name": "test_file_path"},
+          {"name": "use_manifest_chain"},
+          {"name": "validation_mode"}
+        ]
+      }
+    ]
+  },
+  "validationCommand": [
+    "pytest",
+    "tests/test_task_010_type_validation_integration.py",
+    "-v"
+  ]
+}

--- a/tests/test_task_010_type_validation_integration.py
+++ b/tests/test_task_010_type_validation_integration.py
@@ -1,0 +1,347 @@
+"""
+Behavioral tests for Task-010: Type Validation Integration
+
+Tests validate that type hint validation is integrated into the main
+validation workflow, ensuring type mismatches are detected during
+manifest validation.
+
+These tests USE validate_with_ast to verify the integration works correctly.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+import sys
+
+# Add parent directory to path to import validators
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from validators.manifest_validator import validate_with_ast, AlignmentError
+
+
+class TestTypeValidationIntegration:
+    """Test that type validation is integrated into validate_with_ast."""
+
+    def test_detects_missing_parameter_type_hint(self, tmp_path: Path):
+        """Test that missing parameter type hints are detected."""
+        # Create implementation with missing type hint
+        code = """
+def process_data(data):
+    '''Process data'''
+    return True
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        # Manifest declares types
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "process_data",
+                        "parameters": [{"name": "data", "type": "dict"}],
+                        "returns": "bool"
+                    }
+                ]
+            }
+        }
+
+        # Should detect missing type hint
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        assert "type" in error_msg.lower() or "hint" in error_msg.lower()
+
+    def test_detects_wrong_parameter_type(self, tmp_path: Path):
+        """Test that incorrect parameter types are detected."""
+        code = """
+def get_user(user_id: str) -> dict:
+    '''Get user by ID'''
+    return {}
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "get_user",
+                        "parameters": [{"name": "user_id", "type": "int"}],
+                        "returns": "dict"
+                    }
+                ]
+            }
+        }
+
+        # Should detect type mismatch (str vs int)
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        assert "user_id" in error_msg
+        assert "type" in error_msg.lower()
+
+    def test_detects_missing_return_type(self, tmp_path: Path):
+        """Test that missing return type hints are detected."""
+        code = """
+def calculate(x: int, y: int):
+    '''Calculate sum'''
+    return x + y
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "calculate",
+                        "parameters": [
+                            {"name": "x", "type": "int"},
+                            {"name": "y", "type": "int"}
+                        ],
+                        "returns": "int"
+                    }
+                ]
+            }
+        }
+
+        # Should detect missing return type
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        assert "return" in error_msg.lower() or "type" in error_msg.lower()
+
+    def test_detects_wrong_return_type(self, tmp_path: Path):
+        """Test that incorrect return types are detected."""
+        code = """
+def is_valid(value: str) -> str:
+    '''Check if value is valid'''
+    return "yes" if value else "no"
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "is_valid",
+                        "parameters": [{"name": "value", "type": "str"}],
+                        "returns": "bool"
+                    }
+                ]
+            }
+        }
+
+        # Should detect return type mismatch (str vs bool)
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        assert "return" in error_msg.lower()
+        assert "type" in error_msg.lower()
+
+    def test_passes_with_correct_types(self, tmp_path: Path):
+        """Test that correct type hints pass validation."""
+        code = """
+def greet(name: str, age: int) -> str:
+    '''Greet a person'''
+    return f"Hello {name}, age {age}"
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "greet",
+                        "parameters": [
+                            {"name": "name", "type": "str"},
+                            {"name": "age", "type": "int"}
+                        ],
+                        "returns": "str"
+                    }
+                ]
+            }
+        }
+
+        # Should pass - all types match
+        validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+    def test_validates_method_types(self, tmp_path: Path):
+        """Test that method type hints are validated."""
+        code = """
+class UserService:
+    def get_user(self, user_id: str) -> dict:
+        '''Get user by ID'''
+        return {}
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "class",
+                        "name": "UserService"
+                    },
+                    {
+                        "type": "function",
+                        "name": "get_user",
+                        "class": "UserService",
+                        "parameters": [{"name": "user_id", "type": "int"}],
+                        "returns": "dict"
+                    }
+                ]
+            }
+        }
+
+        # Should detect method parameter type mismatch
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        assert "user_id" in error_msg
+        assert "type" in error_msg.lower()
+
+    def test_handles_optional_types(self, tmp_path: Path):
+        """Test that Optional types are handled correctly."""
+        code = """
+from typing import Optional
+
+def find_user(user_id: int) -> Optional[dict]:
+    '''Find user, may return None'''
+    return None
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "find_user",
+                        "parameters": [{"name": "user_id", "type": "int"}],
+                        "returns": "Optional[dict]"
+                    }
+                ]
+            }
+        }
+
+        # Should pass - Optional types match
+        validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+    def test_handles_complex_generic_types(self, tmp_path: Path):
+        """Test that complex generic types are validated."""
+        code = """
+from typing import List, Dict
+
+def process_items(items: List[str]) -> Dict[str, int]:
+    '''Process items and return counts'''
+    return {}
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "process_items",
+                        "parameters": [{"name": "items", "type": "List[str]"}],
+                        "returns": "Dict[str, int]"
+                    }
+                ]
+            }
+        }
+
+        # Should pass - generic types match
+        validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+    def test_error_message_is_actionable(self, tmp_path: Path):
+        """Test that error messages provide actionable information."""
+        code = """
+def bad_function(x: int, y: str) -> None:
+    pass
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "bad_function",
+                        "parameters": [
+                            {"name": "x", "type": "str"},  # Wrong type
+                            {"name": "y", "type": "int"}   # Wrong type
+                        ],
+                        "returns": "bool"  # Wrong type
+                    }
+                ]
+            }
+        }
+
+        # Should provide clear error message
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        # Error should mention function name
+        assert "bad_function" in error_msg
+        # Error should mention type validation
+        assert "type" in error_msg.lower()
+
+    def test_type_validation_runs_in_implementation_mode(self, tmp_path: Path):
+        """Test that type validation runs in implementation mode (default)."""
+        # Missing type hint should cause failure in implementation mode
+        code = """
+def calculate(x):  # Missing type hint
+    return x * 2
+"""
+        impl_file = tmp_path / "test.py"
+        impl_file.write_text(code)
+
+        manifest = {
+            "expectedArtifacts": {
+                "file": str(impl_file),
+                "contains": [
+                    {
+                        "type": "function",
+                        "name": "calculate",
+                        "parameters": [{"name": "x", "type": "int"}],
+                        "returns": "int"
+                    }
+                ]
+            }
+        }
+
+        # Default mode is implementation - should detect missing type hint
+        with pytest.raises(AlignmentError) as exc_info:
+            validate_with_ast(manifest, str(impl_file), use_manifest_chain=False)
+
+        error_msg = str(exc_info.value)
+        assert "type" in error_msg.lower()

--- a/validate_manifest.py
+++ b/validate_manifest.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from validators.manifest_validator import validate_with_ast
 
 
-def extract_test_files_from_command(validation_command):
+def extract_test_files_from_command(validation_command) -> list:
     """
     Extract test file paths from pytest validation commands.
 

--- a/validators/manifest_validator.py
+++ b/validators/manifest_validator.py
@@ -1039,6 +1039,26 @@ def validate_with_ast(
     # Check for unexpected public artifacts (strict mode)
     _check_unexpected_artifacts(expected_items, collector)
 
+    # Type hint validation (only in implementation mode)
+    if validation_mode == _VALIDATION_MODE_IMPLEMENTATION:
+        # Extract type information from manifest
+        manifest_artifacts = manifest_data.get("expectedArtifacts", {})
+
+        # Format implementation type data from collector
+        implementation_artifacts = {
+            "functions": collector.found_function_types,
+            "methods": collector.found_method_types,
+        }
+
+        # Validate type hints match manifest declarations
+        type_errors = validate_type_hints(manifest_artifacts, implementation_artifacts)
+        if type_errors:
+            # Format errors for readability
+            formatted_errors = "\n".join(f"  - {err}" for err in type_errors)
+            raise AlignmentError(
+                f"Type validation failed:\n{formatted_errors}"
+            )
+
 
 def _parse_file(file_path: str) -> ast.AST:
     """Parse a Python file into an AST.


### PR DESCRIPTION
### **User description**
This commit completes the type validation feature by integrating it into the main validation workflow and establishing snapshot-based validation.

## Type Validation Integration (Task-010)

### Implementation
- Integrated validate_type_hints() into validate_with_ast()
- Type validation now runs automatically in implementation mode
- Detects parameter type mismatches, missing type hints, and return type errors
- Clear, actionable error messages for developers

### Test Coverage
- Added 10 comprehensive integration tests
- Tests verify type mismatches are caught during validation
- Tests confirm correct types pass validation
- Tests validate Optional, List, Dict, and complex generic types

### Results
Type validation is now ACTIVE and working:
- Caught real bug: task-004 missing return type annotation
- All 310 tests passing
- Type mismatches now fail validation immediately

## Snapshot Manifest (Task-009)

### Created
- task-009-snapshot-manifest_validator.manifest.json
- Consolidates 6 historical manifests (001, 002, 003, 005, 006, 006a)
- Freezes manifest_validator.py state before new features
- 112 artifacts captured

### Purpose
Enables refactoring without breaking historical manifests. After adding type validation, superseded manifests may fail validation - this is expected as they're historical records.

## Test Suite Updates

### Skip Superseded Manifests
- Modified test_manifest_to_implementation_alignment.py
- Added get_superseded_manifests() to find snapshot supersedes
- Filters out historical manifests from validation
- Only validates active manifests (6) vs all (12)

### Rationale
Snapshot manifests preserve history but supersede validation. After refactoring, old manifests may not match current implementation. This is expected and correct - snapshot is the new source of truth.

## Bug Fix (Task-004)

### Issue
extract_test_files_from_command() missing return type annotation
- Manifest declared: returns "list"
- Implementation had: no type hint

### Fix
Added -> list return type annotation to validate_manifest.py

### Validation
Type validation caught this real bug immediately after integration!

## Files Changed
- validators/manifest_validator.py: Type validation integration
- manifests/task-010-integrate-type-validation.manifest.json: New manifest
- tests/test_task_010_type_validation_integration.py: 10 new tests
- manifests/task-009-snapshot-manifest_validator.manifest.json: New snapshot
- tests/test_manifest_to_implementation_alignment.py: Skip superseded
- validate_manifest.py: Fixed missing return type

## Test Results
✅ 310 tests passing (10 new integration tests added) ✅ All manifests validate correctly
✅ Type validation fully operational
✅ Snapshot workflow working as designed

This closes the critical gap in MAID validation infrastructure and enables safe refactoring through snapshot manifests.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Integrated type hint validation into main validation workflow
  - Type validation now runs automatically in implementation mode
  - Detects parameter type mismatches, missing type hints, return type errors

- Added 10 comprehensive integration tests for type validation
  - Tests verify type mismatches are caught during validation
  - Tests validate Optional, List, Dict, and complex generic types

- Created snapshot manifest to freeze manifest_validator.py state
  - Consolidates 6 historical manifests (001, 002, 003, 005, 006, 006a)
  - Enables safe refactoring without breaking historical records

- Updated test suite to skip superseded manifests
  - Filters out historical manifests from validation checks
  - Only validates active manifests against current implementation

- Fixed missing return type annotation in validate_manifest.py


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Type Validation Integration"] --> B["validate_with_ast"]
  B --> C["Type Hint Validation"]
  C --> D["Error Detection"]
  E["Snapshot Manifest"] --> F["Historical Records"]
  F --> G["Skip Superseded"]
  G --> H["Active Manifests Only"]
  I["Test Suite"] --> J["10 New Tests"]
  J --> K["Type Mismatch Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest_validator.py</strong><dd><code>Integrate type validation into main workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

validators/manifest_validator.py

<ul><li>Integrated <code>validate_type_hints()</code> call into <code>validate_with_ast()</code> <br>function<br> <li> Type validation runs automatically in implementation mode only<br> <li> Extracts type information from manifest and implementation artifacts<br> <li> Formats and raises <code>AlignmentError</code> with detailed type validation errors</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/12/files#diff-1e2ac14033e248e82fb3b7674e79e9758d3fb838ca2875ec483e90a3ec2d8eef">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_manifest_to_implementation_alignment.py</strong><dd><code>Filter superseded manifests from validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_manifest_to_implementation_alignment.py

<ul><li>Added <code>get_superseded_manifests()</code> function to identify <br>snapshot-superseded manifests<br> <li> Modified <code>find_manifest_files()</code> to filter out superseded manifests<br> <li> Updated docstring to explain exclusion of historical snapshot <br>manifests<br> <li> Ensures only active manifests are validated against current <br>implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/12/files#diff-1af2babd4761921bca18f5bbb5f7a7fbb485be55d5658f0d7e627791fa6aa977">+36/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_010_type_validation_integration.py</strong><dd><code>Comprehensive type validation integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_010_type_validation_integration.py

<ul><li>Added 10 comprehensive integration tests for type validation<br> <li> Tests verify detection of missing parameter type hints<br> <li> Tests verify detection of incorrect parameter types<br> <li> Tests verify detection of missing and incorrect return types<br> <li> Tests validate Optional, List, Dict, and complex generic types<br> <li> Tests confirm correct types pass validation<br> <li> Tests verify error messages are actionable and informative</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/12/files#diff-2908e6d1fd8ff498a690c5e2598ed600f24a01490e28487e0f01b211f6618c90">+347/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_manifest.py</strong><dd><code>Add missing return type annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

validate_manifest.py

<ul><li>Added missing return type annotation <code>-> list</code> to <br><code>extract_test_files_from_command()</code> function<br> <li> Fixes type hint mismatch between manifest declaration and <br>implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/12/files#diff-b08acecf57b6a12f2a9e0f714c9d2fd27e14ec2d41d6b2a08ccbbf97dbf01bb5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-009-snapshot-manifest_validator.manifest.json</strong><dd><code>Snapshot manifest for manifest_validator.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-009-snapshot-manifest_validator.manifest.json

<ul><li>Created snapshot manifest freezing manifest_validator.py state<br> <li> Consolidates 6 historical manifests (001, 002, 003, 005, 006, 006a)<br> <li> Captures 112 artifacts from manifest_validator.py<br> <li> Marks superseded manifests to enable safe refactoring</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/12/files#diff-f3741c5eeffeb5f5ddba5a368f9ba2cb6c8e409222ea43db7a2bd812fccd01b5">+1238/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-010-integrate-type-validation.manifest.json</strong><dd><code>Manifest for type validation integration task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-010-integrate-type-validation.manifest.json

<ul><li>New manifest defining type validation integration task<br> <li> Specifies <code>validate_with_ast()</code> as editable artifact<br> <li> Includes validation command for integration tests<br> <li> Marks test file as read-only</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/12/files#diff-61b6a2510df59743854e7287de20fe0b20cd349e47f5825f9a652acb723921c8">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

