### PR TITLE
Maid runner improvements

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -7,14 +7,14 @@ This directory contains Claude Code stop hooks that automatically validate MAID 
 ## Hooks Overview
 
 ### 1. AST Validator Hook (`ast-validator.py`)
-**Purpose**: Validates that manifests are properly aligned with their implementations using AST analysis.
+**Purpose**: Validates that manifests are properly aligned with their implementations using the MAID CLI.
 
 **What it does**:
 - Scans all manifest files in `manifests/` directory
-- For each manifest with an `expectedArtifacts.file`, checks if implementation exists
-- Runs `validate_with_ast()` with manifest chaining to verify alignment
+- For each manifest, runs `uv run maid validate <manifest> --use-manifest-chain --quiet`
+- Validates both behavioral tests and implementation alignment
 - Reports validation results
-- **Blocks Claude from stopping** if AST validation fails
+- **Blocks Claude from stopping** if validation fails
 
 **When it runs**: Every time Claude stops responding (Stop event)
 

--- a/.claude/hooks/ast-validator.py
+++ b/.claude/hooks/ast-validator.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """
 AST Validator Stop Hook
-Validates manifest alignment with implementation using AST analysis.
+Validates manifest alignment with implementation using MAID CLI.
 """
 import json
 import sys
 import os
+import subprocess
 from pathlib import Path
 
 
 def validate_manifest_implementation():
-    """Run AST validation for all manifests with existing implementations."""
+    """Run AST validation for all manifests using maid CLI."""
     try:
         # Read hook input from stdin
         input_data = json.load(sys.stdin)
@@ -23,64 +24,46 @@ def validate_manifest_implementation():
         if input_data.get("stop_hook_active", False):
             return
 
-        print("🔍 Running MAID AST Validation...")
+        print("🔍 Running MAID Validation using CLI...")
 
         # Find all manifests
         manifests_dir = Path("manifests")
         if not manifests_dir.exists():
-            print("📋 No manifests directory found - skipping AST validation")
+            print("📋 No manifests directory found - skipping validation")
             return
 
-        manifest_files = list(manifests_dir.glob("*.json"))
+        manifest_files = sorted(manifests_dir.glob("*.json"))
         if not manifest_files:
-            print("📋 No manifest files found - skipping AST validation")
-            return
-
-        # Check if validator exists
-        if not Path("maid_runner/validators/manifest_validator.py").exists():
-            print("❌ AST validator not found - skipping validation")
+            print("📋 No manifest files found - skipping validation")
             return
 
         validation_results = []
 
-        for manifest_path in sorted(manifest_files):
+        for manifest_path in manifest_files:
             try:
-                # Load manifest
-                with open(manifest_path, "r") as f:
-                    manifest_data = json.load(f)
+                # Run validation using maid CLI
+                print(f"🔍 Validating {manifest_path.name}")
 
-                # Get implementation file
-                impl_file = manifest_data.get("expectedArtifacts", {}).get("file")
-                if not impl_file:
-                    print(f"📋 {manifest_path.name}: No implementation file specified")
-                    continue
-
-                if not Path(impl_file).exists():
-                    print(
-                        f"📋 {manifest_path.name}: Implementation file {impl_file} not found"
-                    )
-                    continue
-
-                # Run AST validation
-                print(f"🔍 Validating {manifest_path.name} against {impl_file}")
-
-                # Import and run validation
-                sys.path.insert(0, ".")
-                from maid_runner.validators.manifest_validator import validate_with_ast
-
-                try:
-                    validate_with_ast(manifest_data, impl_file, use_manifest_chain=True)
-                    print(f"✅ {manifest_path.name}: AST validation passed")
-                    validation_results.append((manifest_path.name, True, None))
-                except Exception as e:
-                    print(f"❌ {manifest_path.name}: AST validation failed - {e}")
-                    validation_results.append((manifest_path.name, False, str(e)))
-
-            except json.JSONDecodeError as e:
-                print(f"❌ {manifest_path.name}: Invalid JSON - {e}")
-                validation_results.append(
-                    (manifest_path.name, False, f"Invalid JSON: {e}")
+                result = subprocess.run(
+                    ["uv", "run", "maid", "validate", str(manifest_path), "--use-manifest-chain", "--quiet"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
                 )
+
+                if result.returncode == 0:
+                    print(f"✅ {manifest_path.name}: Validation passed")
+                    validation_results.append((manifest_path.name, True, None))
+                else:
+                    error_msg = result.stderr.strip() or result.stdout.strip()
+                    print(f"❌ {manifest_path.name}: Validation failed")
+                    if error_msg:
+                        print(f"   {error_msg}")
+                    validation_results.append((manifest_path.name, False, error_msg))
+
+            except subprocess.TimeoutExpired:
+                print(f"⏰ {manifest_path.name}: Validation timed out")
+                validation_results.append((manifest_path.name, False, "Validation timeout"))
             except Exception as e:
                 print(f"❌ {manifest_path.name}: Validation error - {e}")
                 validation_results.append((manifest_path.name, False, str(e)))
@@ -90,7 +73,7 @@ def validate_manifest_implementation():
         passed = sum(1 for _, success, _ in validation_results if success)
         failed = total - passed
 
-        print(f"\n📊 AST Validation Summary: {passed}/{total} passed")
+        print(f"\n📊 Validation Summary: {passed}/{total} passed")
 
         if failed > 0:
             print("❌ Failed validations:")
@@ -101,14 +84,14 @@ def validate_manifest_implementation():
             # Block Claude from stopping if there are validation failures
             output = {
                 "decision": "block",
-                "reason": f"AST validation failed for {failed} manifest(s). Please fix the implementation-manifest alignment issues before proceeding.",
+                "reason": f"Validation failed for {failed} manifest(s). Please fix the implementation-manifest alignment issues before proceeding.",
             }
             print(json.dumps(output))
         else:
             print("✨ All manifests are properly aligned with their implementations!")
 
     except Exception as e:
-        print(f"🔧 AST Validator Hook Error: {e}", file=sys.stderr)
+        print(f"🔧 Validator Hook Error: {e}", file=sys.stderr)
         # Don't block on hook errors
         sys.exit(0)
 

--- a/.claude/hooks/ast-validator.py
+++ b/.claude/hooks/ast-validator.py
@@ -45,7 +45,15 @@ def validate_manifest_implementation():
                 print(f"🔍 Validating {manifest_path.name}")
 
                 result = subprocess.run(
-                    ["uv", "run", "maid", "validate", str(manifest_path), "--use-manifest-chain", "--quiet"],
+                    [
+                        "uv",
+                        "run",
+                        "maid",
+                        "validate",
+                        str(manifest_path),
+                        "--use-manifest-chain",
+                        "--quiet",
+                    ],
                     capture_output=True,
                     text=True,
                     timeout=30,
@@ -63,7 +71,9 @@ def validate_manifest_implementation():
 
             except subprocess.TimeoutExpired:
                 print(f"⏰ {manifest_path.name}: Validation timed out")
-                validation_results.append((manifest_path.name, False, "Validation timeout"))
+                validation_results.append(
+                    (manifest_path.name, False, "Validation timeout")
+                )
             except Exception as e:
                 print(f"❌ {manifest_path.name}: Validation error - {e}")
                 validation_results.append((manifest_path.name, False, str(e)))

--- a/.claude/hooks/test-runner.py
+++ b/.claude/hooks/test-runner.py
@@ -39,7 +39,9 @@ def run_tests():
                         manifest_data = json.load(f)
 
                     # Get validation command (supports both formats)
-                    validation_cmd = manifest_data.get("validationCommand") or manifest_data.get("validationCommands", [{}])[0].get("command")
+                    validation_cmd = manifest_data.get(
+                        "validationCommand"
+                    ) or manifest_data.get("validationCommands", [{}])[0].get("command")
 
                     if validation_cmd:
                         # Convert list to string if needed
@@ -61,16 +63,20 @@ def run_tests():
                             test_results.append((manifest_path.name, True, None))
                         else:
                             print(f"❌ {manifest_path.name}: Tests failed")
-                            error_output = result.stderr.strip() or result.stdout.strip()
+                            error_output = (
+                                result.stderr.strip() or result.stdout.strip()
+                            )
                             if error_output:
                                 # Only show last 10 lines to avoid clutter
-                                error_lines = error_output.split('\n')[-10:]
+                                error_lines = error_output.split("\n")[-10:]
                                 print(f"   {chr(10).join(error_lines)}")
                             test_results.append(
                                 (manifest_path.name, False, error_output)
                             )
                     else:
-                        print(f"📋 {manifest_path.name}: No validation command specified")
+                        print(
+                            f"📋 {manifest_path.name}: No validation command specified"
+                        )
 
                 except json.JSONDecodeError as e:
                     print(f"❌ {manifest_path.name}: Invalid JSON - {e}")
@@ -85,7 +91,11 @@ def run_tests():
                     test_results.append((manifest_path.name, False, str(e)))
 
         # 2. Run integration tests
-        integration_tests = list(Path("tests").glob("test_*_integration.py")) if Path("tests").exists() else []
+        integration_tests = (
+            list(Path("tests").glob("test_*_integration.py"))
+            if Path("tests").exists()
+            else []
+        )
         if integration_tests:
             print(f"\n🔗 Running {len(integration_tests)} integration test file(s)")
 
@@ -162,7 +172,9 @@ def run_tests():
                 print("❌ Failed test suites:")
                 for name, success, error in test_results:
                     if not success:
-                        error_preview = error[:100] + "..." if error and len(error) > 100 else error
+                        error_preview = (
+                            error[:100] + "..." if error and len(error) > 100 else error
+                        )
                         print(f"   • {name}: {error_preview}")
 
                 # Block Claude from stopping if tests fail

--- a/.claude/hooks/test-runner.py
+++ b/.claude/hooks/test-runner.py
@@ -31,27 +31,28 @@ def run_tests():
         # 1. Run tests from manifests
         manifests_dir = Path("manifests")
         if manifests_dir.exists():
-            manifest_files = list(manifests_dir.glob("*.json"))
+            manifest_files = sorted(manifests_dir.glob("*.json"))
 
-            for manifest_path in sorted(manifest_files):
+            for manifest_path in manifest_files:
                 try:
                     with open(manifest_path, "r") as f:
                         manifest_data = json.load(f)
 
-                    validation_cmd = manifest_data.get("validationCommand")
-                    if validation_cmd:
-                        print(
-                            f"🧪 Running tests for {manifest_path.name}: {validation_cmd}"
-                        )
+                    # Get validation command (supports both formats)
+                    validation_cmd = manifest_data.get("validationCommand") or manifest_data.get("validationCommands", [{}])[0].get("command")
 
-                        env = os.environ.copy()
+                    if validation_cmd:
+                        # Convert list to string if needed
+                        if isinstance(validation_cmd, list):
+                            validation_cmd = " ".join(validation_cmd)
+
+                        print(f"🧪 Running tests for {manifest_path.name}")
 
                         result = subprocess.run(
                             validation_cmd,
                             shell=True,
                             capture_output=True,
                             text=True,
-                            env=env,
                             timeout=120,  # 2 minute timeout
                         )
 
@@ -60,19 +61,16 @@ def run_tests():
                             test_results.append((manifest_path.name, True, None))
                         else:
                             print(f"❌ {manifest_path.name}: Tests failed")
-                            print(f"   stdout: {result.stdout}")
-                            print(f"   stderr: {result.stderr}")
+                            error_output = result.stderr.strip() or result.stdout.strip()
+                            if error_output:
+                                # Only show last 10 lines to avoid clutter
+                                error_lines = error_output.split('\n')[-10:]
+                                print(f"   {chr(10).join(error_lines)}")
                             test_results.append(
-                                (
-                                    manifest_path.name,
-                                    False,
-                                    result.stderr or result.stdout,
-                                )
+                                (manifest_path.name, False, error_output)
                             )
                     else:
-                        print(
-                            f"📋 {manifest_path.name}: No validation command specified"
-                        )
+                        print(f"📋 {manifest_path.name}: No validation command specified")
 
                 except json.JSONDecodeError as e:
                     print(f"❌ {manifest_path.name}: Invalid JSON - {e}")
@@ -87,22 +85,18 @@ def run_tests():
                     test_results.append((manifest_path.name, False, str(e)))
 
         # 2. Run integration tests
-        integration_tests = list(Path("tests").glob("test_*_integration.py"))
+        integration_tests = list(Path("tests").glob("test_*_integration.py")) if Path("tests").exists() else []
         if integration_tests:
             print(f"\n🔗 Running {len(integration_tests)} integration test file(s)")
 
             for test_file in sorted(integration_tests):
                 print(f"🧪 Running {test_file.name}")
 
-                env = os.environ.copy()
-
                 try:
                     result = subprocess.run(
-                        f"uv run pytest {test_file} -v",
-                        shell=True,
+                        ["uv", "run", "pytest", str(test_file), "-v"],
                         capture_output=True,
                         text=True,
-                        env=env,
                         timeout=120,
                     )
 
@@ -113,9 +107,9 @@ def run_tests():
                         )
                     else:
                         print(f"❌ {test_file.name}: Integration tests failed")
-                        print(f"   stderr: {result.stderr}")
+                        error_output = result.stderr.strip() or result.stdout.strip()
                         test_results.append(
-                            (f"integration:{test_file.name}", False, result.stderr)
+                            (f"integration:{test_file.name}", False, error_output)
                         )
 
                 except subprocess.TimeoutExpired:
@@ -129,19 +123,15 @@ def run_tests():
                         (f"integration:{test_file.name}", False, str(e))
                     )
 
-        # 3. Run all tests together for comprehensive check
+        # 3. Run comprehensive test suite
         if Path("tests").exists():
             print("\n🧪 Running comprehensive test suite")
 
-            env = os.environ.copy()
-
             try:
                 result = subprocess.run(
-                    "uv run pytest tests/ -v",
-                    shell=True,
+                    ["uv", "run", "pytest", "tests/", "-q"],
                     capture_output=True,
                     text=True,
-                    env=env,
                     timeout=180,  # 3 minute timeout for all tests
                 )
 
@@ -150,8 +140,8 @@ def run_tests():
                     test_results.append(("comprehensive", True, None))
                 else:
                     print("❌ Comprehensive test suite: Some tests failed")
-                    print(f"   stderr: {result.stderr}")
-                    test_results.append(("comprehensive", False, result.stderr))
+                    error_output = result.stderr.strip() or result.stdout.strip()
+                    test_results.append(("comprehensive", False, error_output))
 
             except subprocess.TimeoutExpired:
                 print("⏰ Comprehensive test suite: Timed out")
@@ -172,7 +162,8 @@ def run_tests():
                 print("❌ Failed test suites:")
                 for name, success, error in test_results:
                     if not success:
-                        print(f"   • {name}: {error}")
+                        error_preview = error[:100] + "..." if error and len(error) > 100 else error
+                        print(f"   • {name}: {error_preview}")
 
                 # Block Claude from stopping if tests fail
                 output = {

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/key_learnings_*.md
 .claude/tdd-guard/
 
 backup/
+.claude/conversations/temp/*

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ docs/key_learnings_*.md
 
 backup/
 .claude/conversations/temp/*
+
+maid_agents/.claude/tdd-guard/data/test.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,10 +163,18 @@ uv run maid validate <manifest-path> [--use-manifest-chain] [--quiet]
 # Generate a snapshot manifest from existing code
 uv run maid snapshot <file-path> [--output-dir <dir>]
 
+# List manifests that reference a file
+uv run maid manifests <file-path> [--manifest-dir <dir>] [--quiet]
+
+# Run validation commands from all manifests
+uv run maid test [--manifest-dir <dir>] [--fail-fast] [--verbose]
+
 # Get help
 uv run maid --help
 uv run maid validate --help
 uv run maid snapshot --help
+uv run maid manifests --help
+uv run maid test --help
 ```
 
 ## Quick Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Confirm the high-level goal with user before proceeding.
 1. Draft manifest (`manifests/task-XXX.manifest.json`) - **PRIMARY CONTRACT**
 2. Draft behavioral tests (`tests/test_task_XXX_*.py`) to support and verify the manifest
 3. Run structural validation (checks manifest↔tests AND implementation↔history):
-   `uv run python validate_manifest.py manifests/task-XXX.manifest.json --use-manifest-chain`
+   `uv run maid validate manifests/task-XXX.manifest.json --use-manifest-chain`
 4. Refine BOTH tests & manifest together until validation passes
 
 ### Phase 3: Implementation
@@ -45,7 +45,7 @@ Example Claude Code configurations demonstrating MAID automation are available i
 4. **maid-refactorer** - Phase 3.5: Improves code quality (completes TDD cycle)
 5. **maid-auditor** - Cross-cutting: Enforces strict MAID compliance across all phases
 
-**These are examples only.** MAID Runner itself provides validation tools (`validate_manifest.py`, `generate_snapshot.py`). External tools (Claude Code, custom agents, IDEs) use these validation tools to build automation workflows.
+**These are examples only.** MAID Runner itself provides validation tools via the `maid` CLI (`maid validate`, `maid snapshot`). External tools (Claude Code, custom agents, IDEs) use these CLI commands to build automation workflows.
 
 See `docs/future/claude-code-integration/README.md` for details on building your own automation.
 
@@ -61,7 +61,7 @@ MAID Runner implements and enforces the Manifest-driven AI Development (MAID) me
 
 ### Core Components
 
-1. **Manifest Validator** (`validate_manifest.py`)
+1. **Manifest Validator** (CLI: `maid validate`)
    - Validates manifest JSON against schema
    - Behavioral test validation: Verifies tests USE declared artifacts
    - Implementation validation: Verifies code DEFINES artifacts
@@ -95,7 +95,7 @@ MAID Runner implements and enforces the Manifest-driven AI Development (MAID) me
 
 ## Validation Flow
 
-The `validate_manifest.py` script performs validation in this order:
+The `maid validate` command performs validation in this order:
 
 1. **Schema Validation**: Ensures manifest follows the JSON schema
 2. **Behavioral Test Validation**: Verifies test files USE the declared artifacts (AST-based)
@@ -134,6 +134,23 @@ Note: Behavioral validation only checks artifacts from the current manifest, not
 }
 ```
 
+## MAID CLI Commands
+
+**IMPORTANT: Always use the `maid` CLI for validation and snapshots, NOT direct Python scripts.**
+
+```bash
+# Validate a manifest (with optional manifest chain)
+uv run maid validate <manifest-path> [--use-manifest-chain] [--quiet]
+
+# Generate a snapshot manifest from existing code
+uv run maid snapshot <file-path> [--output-dir <dir>]
+
+# Get help
+uv run maid --help
+uv run maid validate --help
+uv run maid snapshot --help
+```
+
 ## Quick Commands
 
 ```bash
@@ -147,7 +164,7 @@ ls manifests/task-*.manifest.json | tail -1
 
 # Validation Flow
 # 1. Structural validation (pre-implementation)
-uv run python validate_manifest.py manifests/task-XXX.manifest.json --use-manifest-chain
+uv run maid validate manifests/task-XXX.manifest.json --use-manifest-chain
 
 # 2. The validator now runs THREE checks:
 #    a) Schema validation (manifest structure)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,26 @@ The `maid validate` command performs validation in this order:
 1. **Schema Validation**: Ensures manifest follows the JSON schema
 2. **Behavioral Test Validation**: Verifies test files USE the declared artifacts (AST-based)
 3. **Implementation Validation**: Verifies implementation DEFINES the artifacts
+4. **File Tracking Analysis** (when using `--use-manifest-chain`): Detects undeclared and partially compliant files
 
 Note: Behavioral validation only checks artifacts from the current manifest, not the merged chain.
+
+### File Tracking Analysis
+
+When using `--use-manifest-chain` in implementation mode, MAID Runner performs automatic file tracking analysis with a two-level warning system:
+
+- **🔴 UNDECLARED** (High Priority): Files exist in codebase but not in any manifest
+  - No audit trail of when/why created
+  - **Action**: Add to `creatableFiles` or `editableFiles` in a manifest
+
+- **🟡 REGISTERED** (Medium Priority): Files in manifests but incomplete compliance
+  - Issues: Missing `expectedArtifacts`, no tests, or only in `readonlyFiles`
+  - **Action**: Add `expectedArtifacts` and `validationCommand` for full compliance
+
+- **✓ TRACKED** (Clean): Files with full MAID compliance
+  - Properly documented with artifacts and behavioral tests
+
+This progressive compliance system helps identify accountability gaps and supports gradual migration to MAID.
 
 ## Validation Modes (MAID v1.2)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A tool-agnostic validation framework for the Manifest-driven AI Development (MAI
 │   ✓ Validate implementation          │
 │   ✓ Validate type hints              │
 │   ✓ Validate manifest chain          │
+│   ✓ Track file compliance            │
 │                                      │
 │   ✗ No file creation                 │
 │   ✗ No code generation               │
@@ -123,6 +124,50 @@ $ maid validate manifests/task-013.manifest.json --use-manifest-chain
 $ maid validate manifests/task-013.manifest.json --quiet
 # Exit code 0 = success, no output
 ```
+
+**File Tracking Analysis:**
+
+When using `--use-manifest-chain` in implementation mode, MAID Runner performs automatic file tracking analysis to detect files not properly tracked in manifests:
+
+```bash
+$ maid validate manifests/task-013.manifest.json --use-manifest-chain
+
+✓ Validation PASSED
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FILE TRACKING ANALYSIS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+🔴 UNDECLARED FILES (3 files)
+  Files exist in codebase but are not tracked in any manifest
+
+  - scripts/helper.py
+    → Not found in any manifest
+
+  Action: Add these files to creatableFiles or editableFiles
+
+🟡 REGISTERED FILES (5 files)
+  Files are tracked but not fully MAID-compliant
+
+  - utils/config.py
+    ⚠️  In editableFiles but no expectedArtifacts
+    Manifests: task-010
+
+  Action: Add expectedArtifacts and validationCommand
+
+✓ TRACKED (42 files)
+  All other source files are fully MAID-compliant
+
+Summary: 3 UNDECLARED, 5 REGISTERED, 42 TRACKED
+```
+
+**File Status Levels:**
+
+- **🔴 UNDECLARED**: Files not in any manifest (high priority) - no audit trail
+- **🟡 REGISTERED**: Files tracked but incomplete compliance (medium priority) - missing artifacts/tests
+- **✓ TRACKED**: Files with full MAID compliance - properly documented and tested
+
+This progressive compliance system helps teams migrate existing codebases to MAID while clearly identifying accountability gaps.
 
 ### 2. Snapshot Generation
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,51 @@ $ maid snapshot maid_runner/validators/manifest_validator.py --force
 Snapshot manifest generated successfully: manifests/task-009-snapshot-manifest_validator.manifest.json
 ```
 
+### 3. List Manifests by File
+
+```bash
+# List all manifests that reference a file
+maid manifests <file_path> [options]
+
+# Options:
+#   --manifest-dir DIR  # Default: manifests/
+#   --quiet, -q         # Show minimal output (just manifest names)
+
+# Exit Codes:
+#   0 = Success (found or not found)
+```
+
+**Examples:**
+
+```bash
+# Find which manifests reference a file
+$ maid manifests maid_runner/cli/main.py
+
+Manifests referencing: maid_runner/cli/main.py
+Total: 2 manifest(s)
+
+================================================================================
+
+✏️  EDITED BY (2 manifest(s)):
+  - task-021-maid-test-command.manifest.json
+  - task-029-list-manifests-command.manifest.json
+
+================================================================================
+
+# Quiet mode for scripting
+$ maid manifests maid_runner/validators/manifest_validator.py --quiet
+created: task-001-add-schema-validation.manifest.json
+edited: task-002-add-ast-alignment-validation.manifest.json
+edited: task-003-behavioral-validation.manifest.json
+read: task-008-snapshot-generator.manifest.json
+```
+
+**Use Cases:**
+- **Dependency Analysis**: Find which tasks touched a file
+- **Impact Assessment**: Understand file's role in the project (created vs edited vs read)
+- **Manifest Discovery**: Quickly locate relevant manifests when investigating code
+- **Audit Trail**: See the complete history of changes to a file through manifests
+
 ## Optional Human Helper Tools
 
 For manual/interactive use, MAID Runner includes convenience wrappers in `examples/maid_runner.py`:
@@ -303,6 +348,7 @@ fi
 | **Implementation** | Code DEFINES declared artifacts | `maid validate` (default) |
 | **Type Hints** | Type annotations match manifest | `maid validate` (automatic) |
 | **Manifest Chain** | Historical consistency | `maid validate --use-manifest-chain` |
+| **File References** | Which manifests touch a file | `maid manifests <file_path>` |
 
 ## Development Setup
 
@@ -445,10 +491,13 @@ maid-runner/
 │   ├── cli/                        # CLI modules
 │   │   ├── main.py                # Main CLI entry point (maid command)
 │   │   ├── validate.py            # Validate subcommand
-│   │   └── snapshot.py            # Snapshot subcommand
+│   │   ├── snapshot.py            # Snapshot subcommand
+│   │   ├── list_manifests.py      # Manifests subcommand
+│   │   └── test.py                # Test subcommand
 │   └── validators/                # Core validation logic
 │       ├── manifest_validator.py  # Main validation engine
 │       ├── type_validator.py      # Type hint validation
+│       ├── file_tracker.py        # File tracking analysis
 │       └── schemas/               # JSON schemas
 ├── examples/                      # Example scripts
 │   └── maid_runner.py             # Optional helpers (plan/run)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A tool-agnostic validation framework for the Manifest-driven AI Development (MAID) methodology. MAID Runner validates that code artifacts align with their declarative manifests, ensuring architectural integrity in AI-assisted development.
 
+## Project Journey & Re-energizer
+
+**Getting Back on Track**: After several months away from this project due to life priorities, returning to a codebase can feel overwhelming. This video serves as a personal re-energizer—a way to reconnect with the project's vision, remember why it matters, and reignite the passion for building tools that make AI-assisted development more reliable and maintainable.
+
+If you're picking up this project after a break, or if you're curious about the motivation behind MAID Runner, [watch this video](https://www.loom.com/share/4f6b18b097984a10baeb96b1da505989) to understand the journey and the excitement that drives this work forward.
+
 ## Architecture Philosophy
 
 **MAID Runner is a validation-only tool.** It does NOT create files, generate code, or automate development. Instead, it validates that manifests, tests, and implementations comply with MAID methodology.

--- a/maid_runner/cli/init.py
+++ b/maid_runner/cli/init.py
@@ -1,0 +1,293 @@
+"""Initialize MAID methodology in an existing repository.
+
+This module provides the 'maid init' command to set up the necessary
+directory structure and documentation for using MAID in a project.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+
+def create_directories(target_dir: str) -> None:
+    """Create necessary directories for MAID methodology.
+
+    Args:
+        target_dir: Target directory to initialize MAID in
+    """
+    manifests_dir = Path(target_dir) / "manifests"
+    tests_dir = Path(target_dir) / "tests"
+    maid_docs_dir = Path(target_dir) / ".maid" / "docs"
+
+    # Create manifests directory
+    manifests_dir.mkdir(exist_ok=True)
+    print(f"✓ Created directory: {manifests_dir}")
+
+    # Create tests directory
+    tests_dir.mkdir(exist_ok=True)
+    print(f"✓ Created directory: {tests_dir}")
+
+    # Create .maid/docs directory
+    maid_docs_dir.mkdir(parents=True, exist_ok=True)
+    print(f"✓ Created directory: {maid_docs_dir}")
+
+
+def create_example_manifest(target_dir: str) -> None:
+    """Create an example manifest file to help users get started.
+
+    Args:
+        target_dir: Target directory containing manifests/ subdirectory
+    """
+    example_manifest = {
+        "goal": "Example task - replace with your actual task description",
+        "taskType": "create",
+        "supersedes": [],
+        "creatableFiles": [],
+        "editableFiles": [],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "path/to/your/file.py",
+            "contains": [
+                {
+                    "type": "function",
+                    "name": "example_function",
+                    "args": [{"name": "arg1", "type": "str"}],
+                    "returns": "None",
+                }
+            ],
+        },
+        "validationCommand": ["pytest", "tests/test_example.py", "-v"],
+    }
+
+    example_path = Path(target_dir) / "manifests" / "example.manifest.json"
+    with open(example_path, "w") as f:
+        json.dump(example_manifest, f, indent=2)
+
+    print(f"✓ Created example manifest: {example_path}")
+
+
+def copy_maid_specs(target_dir: str) -> None:
+    """Copy MAID specification document to .maid/docs directory.
+
+    Args:
+        target_dir: Target directory containing .maid/docs subdirectory
+    """
+    # Get the path to maid_specs.md in the maid-runner installation
+    # We'll look for it relative to this module's location
+    current_file = Path(__file__)
+    maid_runner_root = current_file.parent.parent.parent
+    source_specs = maid_runner_root / "docs" / "maid_specs.md"
+
+    if not source_specs.exists():
+        print(
+            f"⚠️  Warning: Could not find maid_specs.md at {source_specs}. Skipping copy."
+        )
+        return
+
+    dest_specs = Path(target_dir) / ".maid" / "docs" / "maid_specs.md"
+    shutil.copy2(source_specs, dest_specs)
+    print(f"✓ Copied MAID specification: {dest_specs}")
+
+
+def generate_claude_md_content() -> str:
+    """Generate MAID documentation content for CLAUDE.md.
+
+    Returns:
+        String containing MAID workflow documentation
+    """
+    content = """# MAID Methodology
+
+**This project uses Manifest-driven AI Development (MAID) v1.2**
+
+MAID is a methodology for developing software with AI assistance by explicitly declaring:
+- What files can be modified for each task
+- What code artifacts (functions, classes) should be created or modified
+- How to validate that the changes meet requirements
+
+This project is compatible with MAID-aware AI agents including Claude Code and other tools that understand the MAID workflow.
+
+## MAID Workflow
+
+### Phase 1: Goal Definition
+Confirm the high-level goal before proceeding.
+
+### Phase 2: Planning Loop
+**Before ANY implementation - iterative refinement:**
+1. Draft manifest (`manifests/task-XXX.manifest.json`)
+2. Draft behavioral tests (`tests/test_task_XXX_*.py`)
+3. Run validation: `maid validate manifests/task-XXX.manifest.json --validation-mode behavioral`
+4. Refine both tests & manifest until validation passes
+
+### Phase 3: Implementation
+1. Load ONLY files from manifest (`editableFiles` + `readonlyFiles`)
+2. Implement code to pass tests
+3. Run behavioral validation (from `validationCommand`)
+4. Iterate until all tests pass
+
+### Phase 4: Integration
+Verify complete chain: `pytest tests/ -v` (or your test command)
+
+## Manifest Template
+
+```json
+{
+  "goal": "Clear task description",
+  "taskType": "edit|create|refactor",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [],
+  "readonlyFiles": [],
+  "expectedArtifacts": {
+    "file": "path/to/file.py",
+    "contains": [
+      {
+        "type": "function|class|attribute",
+        "name": "artifact_name",
+        "class": "ParentClass",
+        "args": [{"name": "arg1", "type": "str"}],
+        "returns": "ReturnType"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_file.py", "-v"]
+}
+```
+
+## MAID CLI Commands
+
+```bash
+# Validate a manifest
+maid validate <manifest-path> [--validation-mode behavioral|implementation]
+
+# Generate a snapshot manifest from existing code
+maid snapshot <file-path> [--output-dir <dir>]
+
+# List manifests that reference a file
+maid manifests <file-path> [--manifest-dir <dir>]
+
+# Run all validation commands
+maid test [--manifest-dir <dir>]
+
+# Get help
+maid --help
+```
+
+## Validation Modes
+
+- **Strict Mode** (`creatableFiles`): Implementation must EXACTLY match `expectedArtifacts`
+- **Permissive Mode** (`editableFiles`): Implementation must CONTAIN `expectedArtifacts` (allows existing code)
+
+## Key Rules
+
+**NEVER:** Modify code without manifest | Skip validation | Access unlisted files
+**ALWAYS:** Manifest first → Tests → Implementation → Validate
+
+## Artifact Rules
+
+- **Public** (no `_` prefix): MUST be in manifest
+- **Private** (`_` prefix): Optional in manifest
+- **creatableFiles**: Strict validation (exact match)
+- **editableFiles**: Permissive validation (contains at least)
+
+## Getting Started
+
+1. Create your first manifest in `manifests/task-001-<description>.manifest.json`
+2. Write behavioral tests in `tests/test_task_001_*.py`
+3. Validate: `maid validate manifests/task-001-<description>.manifest.json --validation-mode behavioral`
+4. Implement the code
+5. Run tests to verify: `maid test`
+
+## Additional Resources
+
+- **Full MAID Specification**: See `.maid/docs/maid_specs.md` for complete methodology details
+- **MAID Runner Repository**: https://github.com/mamertofabian/maid-runner
+"""
+    return content
+
+
+def handle_claude_md(target_dir: str, force: bool) -> None:
+    """Create or update CLAUDE.md file with MAID documentation.
+
+    Args:
+        target_dir: Target directory for CLAUDE.md
+        force: If True, overwrite without prompting
+    """
+    claude_md_path = Path(target_dir) / "CLAUDE.md"
+    content = generate_claude_md_content()
+
+    # If file doesn't exist, just create it
+    if not claude_md_path.exists():
+        claude_md_path.write_text(content)
+        print(f"✓ Created CLAUDE.md: {claude_md_path}")
+        return
+
+    # File exists - handle based on force flag
+    if force:
+        claude_md_path.write_text(content)
+        print(f"✓ Overwrote CLAUDE.md: {claude_md_path}")
+        return
+
+    # Prompt user for action
+    print(f"\n⚠️  CLAUDE.md already exists at: {claude_md_path}")
+    print("\nWhat would you like to do?")
+    print("  [a] Append MAID documentation to existing file")
+    print("  [o] Overwrite file with MAID documentation")
+    print("  [s] Skip - don't modify existing file")
+
+    while True:
+        choice = input("\nYour choice (a/o/s): ").strip().lower()
+        if choice in ["a", "o", "s"]:
+            break
+        print("Invalid choice. Please enter 'a', 'o', or 's'.")
+
+    if choice == "a":
+        # Append to existing file
+        existing_content = claude_md_path.read_text()
+        combined_content = existing_content + "\n\n" + "# " * 40 + "\n\n" + content
+        claude_md_path.write_text(combined_content)
+        print(f"✓ Appended MAID documentation to: {claude_md_path}")
+    elif choice == "o":
+        # Overwrite
+        claude_md_path.write_text(content)
+        print(f"✓ Overwrote CLAUDE.md: {claude_md_path}")
+    else:  # skip
+        print("⊘ Skipped CLAUDE.md (existing file unchanged)")
+
+
+def run_init(target_dir: str, force: bool) -> None:
+    """Initialize MAID methodology in a repository.
+
+    Args:
+        target_dir: Target directory to initialize MAID in
+        force: If True, overwrite files without prompting
+    """
+    print(f"\n{'=' * 60}")
+    print("Initializing MAID Methodology")
+    print(f"{'=' * 60}\n")
+
+    # Create directory structure
+    create_directories(target_dir)
+
+    # Create example manifest
+    create_example_manifest(target_dir)
+
+    # Copy MAID specification document
+    copy_maid_specs(target_dir)
+
+    # Handle CLAUDE.md
+    handle_claude_md(target_dir, force)
+
+    print(f"\n{'=' * 60}")
+    print("✓ MAID initialization complete!")
+    print(f"{'=' * 60}\n")
+    print("Next steps:")
+    print("1. Review the example manifest in manifests/example.manifest.json")
+    print(
+        "2. Create your first task manifest: manifests/task-001-<description>.manifest.json"
+    )
+    print("3. Write behavioral tests in tests/test_task_001_*.py")
+    print(
+        "4. Validate: maid validate manifests/task-001-<description>.manifest.json --validation-mode behavioral"
+    )
+    print("5. Implement your code")
+    print("6. Run tests: maid test\n")

--- a/maid_runner/cli/init.py
+++ b/maid_runner/cli/init.py
@@ -243,7 +243,7 @@ def handle_claude_md(target_dir: str, force: bool) -> None:
     if choice == "a":
         # Append to existing file
         existing_content = claude_md_path.read_text()
-        combined_content = existing_content + "\n\n" + "# " * 40 + "\n\n" + content
+        combined_content = existing_content + "\n\n" + "=" * 40 + "\n\n" + content
         claude_md_path.write_text(combined_content)
         print(f"✓ Appended MAID documentation to: {claude_md_path}")
     elif choice == "o":

--- a/maid_runner/cli/list_manifests.py
+++ b/maid_runner/cli/list_manifests.py
@@ -1,0 +1,176 @@
+"""List manifests CLI command for MAID Runner.
+
+Provides a command to list all manifests that reference a given file,
+categorized by how they reference it (created, edited, or read).
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def _categorize_manifest_by_file(manifest_data: dict, file_path: str) -> Optional[str]:
+    """Categorize how a manifest references a file.
+
+    Args:
+        manifest_data: Dictionary containing the manifest data
+        file_path: Path to the file to check
+
+    Returns:
+        "created" if file is in creatableFiles
+        "edited" if file is in editableFiles
+        "read" if file is in readonlyFiles
+        None if file is not referenced
+
+    Note:
+        Priority order: created > edited > read
+        If a file appears in multiple lists, the highest priority category is returned.
+    """
+    # Check in priority order
+    if file_path in manifest_data.get("creatableFiles", []):
+        return "created"
+    if file_path in manifest_data.get("editableFiles", []):
+        return "edited"
+    if file_path in manifest_data.get("readonlyFiles", []):
+        return "read"
+
+    return None
+
+
+def _format_manifest_list_output(
+    categorized_manifests: dict, file_path: str, quiet: bool
+) -> None:
+    """Format and print the categorized manifest list.
+
+    Args:
+        categorized_manifests: Dictionary with categories as keys and manifest lists as values
+        file_path: The file path being searched
+        quiet: If True, show minimal output (just manifest names)
+    """
+    # Count total manifests
+    total_count = sum(len(manifests) for manifests in categorized_manifests.values())
+
+    if total_count == 0:
+        print(f"No manifests found referencing: {file_path}")
+        return
+
+    # Print header (unless quiet)
+    if not quiet:
+        print(f"\nManifests referencing: {file_path}")
+        print(f"Total: {total_count} manifest(s)\n")
+        print("=" * 80)
+
+    # Print each category
+    categories = ["created", "edited", "read"]
+    category_labels = {
+        "created": "📝 CREATED BY",
+        "edited": "✏️  EDITED BY",
+        "read": "👀 READ BY",
+    }
+
+    for category in categories:
+        manifests = categorized_manifests.get(category, [])
+        if not manifests:
+            continue
+
+        if quiet:
+            # Quiet mode: just list manifest names
+            for manifest_name in manifests:
+                print(f"{category}: {manifest_name}")
+        else:
+            # Verbose mode: formatted output with labels
+            label = category_labels.get(category, category.upper())
+            print(f"\n{label} ({len(manifests)} manifest(s)):")
+            for manifest_name in manifests:
+                print(f"  - {manifest_name}")
+
+    if not quiet:
+        print("\n" + "=" * 80)
+
+
+def run_list_manifests(file_path: str, manifest_dir: str, quiet: bool) -> None:
+    """List all manifests that reference a given file.
+
+    Scans all manifests in the specified directory and categorizes them by
+    how they reference the target file (created, edited, or read).
+
+    Args:
+        file_path: Path to the file to search for in manifests
+        manifest_dir: Directory containing manifest files
+        quiet: If True, show minimal output
+
+    Raises:
+        SystemExit: Exits with code 1 if manifest_dir doesn't exist
+    """
+    manifest_dir_path = Path(manifest_dir)
+
+    # Validate manifest directory exists
+    if not manifest_dir_path.exists():
+        print(f"Error: Manifest directory not found: {manifest_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Find all manifest files
+    manifest_files = sorted(manifest_dir_path.glob("task-*.manifest.json"))
+
+    if not manifest_files:
+        print(f"No manifest files found in: {manifest_dir}")
+        return
+
+    # Categorize manifests
+    categorized = {
+        "created": [],
+        "edited": [],
+        "read": [],
+    }
+
+    for manifest_file in manifest_files:
+        try:
+            with open(manifest_file, "r") as f:
+                manifest_data = json.load(f)
+
+            # Categorize this manifest
+            category = _categorize_manifest_by_file(manifest_data, file_path)
+
+            if category:
+                categorized[category].append(manifest_file.name)
+
+        except (json.JSONDecodeError, IOError) as e:
+            # Skip invalid manifests with a warning
+            if not quiet:
+                print(
+                    f"Warning: Skipping invalid manifest {manifest_file.name}: {e}",
+                    file=sys.stderr,
+                )
+            continue
+
+    # Format and display results
+    _format_manifest_list_output(categorized, file_path, quiet)
+
+
+def _main() -> None:
+    """CLI entry point for standalone testing (private)."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="List all manifests that reference a given file"
+    )
+    parser.add_argument("file_path", help="Path to the file to search for")
+    parser.add_argument(
+        "--manifest-dir",
+        default="manifests",
+        help="Directory containing manifests (default: manifests)",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Show minimal output (just manifest names)",
+    )
+
+    args = parser.parse_args()
+    run_list_manifests(args.file_path, args.manifest_dir, args.quiet)
+
+
+if __name__ == "__main__":
+    _main()

--- a/maid_runner/cli/list_manifests.py
+++ b/maid_runner/cli/list_manifests.py
@@ -9,6 +9,11 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from maid_runner.utils import (
+    print_maid_not_enabled_message,
+    print_no_manifests_found_message,
+)
+
 
 def _categorize_manifest_by_file(manifest_data: dict, file_path: str) -> Optional[str]:
     """Categorize how a manifest references a file.
@@ -107,14 +112,14 @@ def run_list_manifests(file_path: str, manifest_dir: str, quiet: bool) -> None:
 
     # Validate manifest directory exists
     if not manifest_dir_path.exists():
-        print(f"Error: Manifest directory not found: {manifest_dir}", file=sys.stderr)
+        print_maid_not_enabled_message(manifest_dir, use_stderr=True)
         sys.exit(1)
 
     # Find all manifest files
     manifest_files = sorted(manifest_dir_path.glob("task-*.manifest.json"))
 
     if not manifest_files:
-        print(f"No manifest files found in: {manifest_dir}")
+        print_no_manifests_found_message(manifest_dir)
         return
 
     # Categorize manifests

--- a/maid_runner/cli/main.py
+++ b/maid_runner/cli/main.py
@@ -75,6 +75,46 @@ def main():
         help="Overwrite existing manifests without prompting",
     )
 
+    # Test subcommand
+    test_parser = subparsers.add_parser(
+        "test",
+        help="Run validation commands from all non-superseded manifests",
+        description="Run validation commands from all non-superseded manifests",
+    )
+    test_parser.add_argument(
+        "--manifest",
+        "-m",
+        help="Run validation commands for a single manifest (filename relative to manifest-dir or absolute path)",
+    )
+    test_parser.add_argument(
+        "--manifest-dir",
+        default="manifests",
+        help="Directory containing manifests (default: manifests)",
+    )
+    test_parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop execution on first failure",
+    )
+    test_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show detailed command output",
+    )
+    test_parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Only show summary (suppress per-manifest output)",
+    )
+    test_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Command timeout in seconds (default: 300)",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -94,6 +134,17 @@ def main():
         from maid_runner.cli.snapshot import run_snapshot
 
         run_snapshot(args.file_path, args.output_dir, args.force)
+    elif args.command == "test":
+        from maid_runner.cli.test import run_test
+
+        run_test(
+            args.manifest_dir,
+            args.fail_fast,
+            args.verbose,
+            args.quiet,
+            args.timeout,
+            args.manifest,
+        )
     else:
         parser.print_help()
         sys.exit(1)

--- a/maid_runner/cli/main.py
+++ b/maid_runner/cli/main.py
@@ -3,8 +3,11 @@
 
 Provides a unified command-line interface with subcommands:
 - maid --version
+- maid init ...
 - maid validate ...
 - maid snapshot ...
+- maid test ...
+- maid manifests ...
 """
 
 import argparse
@@ -144,6 +147,23 @@ def main():
         help="Show minimal output (just manifest names)",
     )
 
+    # Init subcommand
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Initialize MAID methodology in an existing repository",
+        description="Initialize MAID methodology by creating directory structure and documentation",
+    )
+    init_parser.add_argument(
+        "--target-dir",
+        default=".",
+        help="Target directory to initialize (default: current directory)",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files without prompting",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -199,6 +219,10 @@ def main():
         from maid_runner.cli.list_manifests import run_list_manifests
 
         run_list_manifests(args.file_path, args.manifest_dir, args.quiet)
+    elif args.command == "init":
+        from maid_runner.cli.init import run_init
+
+        run_init(args.target_dir, args.force)
     else:
         parser.print_help()
         sys.exit(1)

--- a/maid_runner/cli/main.py
+++ b/maid_runner/cli/main.py
@@ -123,6 +123,27 @@ def main():
         help="Command timeout in seconds (default: 300)",
     )
 
+    # List-manifests subcommand
+    list_manifests_parser = subparsers.add_parser(
+        "manifests",
+        help="List all manifests that reference a given file",
+        description="List all manifests that reference a given file, categorized by how they reference it (created, edited, or read)",
+    )
+    list_manifests_parser.add_argument(
+        "file_path", help="Path to the file to search for in manifests"
+    )
+    list_manifests_parser.add_argument(
+        "--manifest-dir",
+        default="manifests",
+        help="Directory containing manifests (default: manifests)",
+    )
+    list_manifests_parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Show minimal output (just manifest names)",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -174,6 +195,10 @@ def main():
             args.timeout,
             args.manifest,
         )
+    elif args.command == "manifests":
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        run_list_manifests(args.file_path, args.manifest_dir, args.quiet)
     else:
         parser.print_help()
         sys.exit(1)

--- a/maid_runner/cli/main.py
+++ b/maid_runner/cli/main.py
@@ -50,7 +50,7 @@ def main():
     validate_parser.add_argument(
         "--use-manifest-chain",
         action="store_true",
-        help="Use manifest chain to merge all related manifests (automatically enabled for directory validation)",
+        help="Use manifest chain to merge all related manifests (enables file tracking analysis; automatically enabled for directory validation)",
     )
     validate_parser.add_argument(
         "--quiet",

--- a/maid_runner/cli/test.py
+++ b/maid_runner/cli/test.py
@@ -15,6 +15,8 @@ from typing import Optional
 from maid_runner.utils import (
     get_superseded_manifests,
     normalize_validation_commands,
+    print_maid_not_enabled_message,
+    print_no_manifests_found_message,
     validate_manifest_version,
 )
 
@@ -159,7 +161,7 @@ def run_test(
     project_root = manifests_dir.parent
 
     if not manifests_dir.exists():
-        print(f"⚠️  Manifests directory not found: {manifest_dir}")
+        print_maid_not_enabled_message(str(manifest_dir))
         sys.exit(0)
 
     # If a specific manifest is requested, use only that one
@@ -178,7 +180,7 @@ def run_test(
         # Default behavior: process all non-superseded manifests
         manifest_files = sorted(manifests_dir.glob("task-*.manifest.json"))
         if not manifest_files:
-            print("⚠️  No manifest files found")
+            print_no_manifests_found_message(str(manifest_dir))
             sys.exit(0)
 
         # Get superseded manifests and filter them out

--- a/maid_runner/cli/test.py
+++ b/maid_runner/cli/test.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Command-line interface for running MAID validation commands.
+
+This script discovers all manifests, filters out superseded ones, and executes
+their validation commands, providing aggregate results.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from maid_runner.utils import (
+    get_superseded_manifests,
+    normalize_validation_commands,
+    validate_manifest_version,
+)
+
+
+def execute_validation_commands(
+    manifest_path: Path,
+    manifest_data: dict,
+    timeout: int,
+    verbose: bool,
+    project_root: Path,
+) -> tuple:
+    """Execute validation commands for a single manifest.
+
+    Args:
+        manifest_path: Path to the manifest file
+        manifest_data: Dictionary containing manifest data
+        timeout: Command timeout in seconds
+        verbose: If True, show detailed command output
+        project_root: Project root directory (parent of manifests dir) where commands should be executed
+
+    Returns:
+        tuple: (passed_count, failed_count, total_count)
+    """
+    validation_commands = normalize_validation_commands(manifest_data)
+
+    if not validation_commands:
+        return (0, 0, 0)
+
+    passed = 0
+    failed = 0
+    total = len(validation_commands)
+
+    # Get project directory name for path normalization
+    project_name = project_root.name
+
+    for i, cmd in enumerate(validation_commands):
+        if not cmd:
+            continue
+
+        # Normalize command paths: strip redundant project directory prefix
+        # E.g., if project_root is /path/to/maid_agents and command has maid_agents/tests/...,
+        # strip the maid_agents/ prefix so it becomes tests/...
+        normalized_cmd = []
+        for arg in cmd:
+            if "/" in arg and arg.startswith(f"{project_name}/"):
+                # Strip the redundant project directory prefix
+                normalized_arg = arg[len(project_name) + 1 :]
+                normalized_cmd.append(normalized_arg)
+            else:
+                normalized_cmd.append(arg)
+
+        cmd_str = " ".join(normalized_cmd)
+        print(f"  [{i+1}/{total}] {cmd_str}")
+
+        try:
+            result = subprocess.run(
+                normalized_cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=project_root,
+            )
+
+            if result.returncode == 0:
+                passed += 1
+                print("    ✅ PASSED")
+                if verbose and result.stdout:
+                    for line in result.stdout.strip().split("\n"):
+                        print(f"      {line}")
+            else:
+                failed += 1
+                print(f"    ❌ FAILED (exit code: {result.returncode})")
+                if result.stderr:
+                    # Print first few lines of stderr
+                    stderr_lines = result.stderr.strip().split("\n")[:10]
+                    for line in stderr_lines:
+                        print(f"      {line}")
+
+        except subprocess.TimeoutExpired:
+            failed += 1
+            print(f"    ⏰ TIMEOUT (>{timeout}s)")
+        except FileNotFoundError:
+            failed += 1
+            print(f"    ❌ Command not found: {cmd[0]}")
+        except Exception as e:
+            failed += 1
+            print(f"    ❌ Error: {e}")
+
+    return (passed, failed, total)
+
+
+def run_test(
+    manifest_dir: str,
+    fail_fast: bool,
+    verbose: bool,
+    quiet: bool,
+    timeout: int,
+    manifest_path: Optional[str] = None,
+) -> None:
+    """Run all validation commands from active manifests.
+
+    Args:
+        manifest_dir: Path to the manifests directory
+        fail_fast: If True, stop on first failure
+        verbose: If True, show detailed output
+        quiet: If True, only show summary
+        timeout: Command timeout in seconds
+        manifest_path: Optional path to a single manifest to test (relative to manifest_dir or absolute)
+
+    Raises:
+        SystemExit: Exits with code 0 on success, 1 on failure
+    """
+    manifests_dir = Path(manifest_dir).resolve()
+    project_root = manifests_dir.parent
+
+    if not manifests_dir.exists():
+        print(f"⚠️  Manifests directory not found: {manifest_dir}")
+        sys.exit(0)
+
+    # If a specific manifest is requested, use only that one
+    if manifest_path:
+        specific_manifest = Path(manifest_path)
+        # If path is relative, resolve it relative to manifests_dir
+        if not specific_manifest.is_absolute():
+            specific_manifest = manifests_dir / specific_manifest
+
+        if not specific_manifest.exists():
+            print(f"⚠️  Manifest file not found: {manifest_path}")
+            sys.exit(1)
+
+        active_manifests = [specific_manifest.resolve()]
+    else:
+        # Default behavior: process all non-superseded manifests
+        manifest_files = sorted(manifests_dir.glob("task-*.manifest.json"))
+        if not manifest_files:
+            print("⚠️  No manifest files found")
+            sys.exit(0)
+
+        # Get superseded manifests and filter them out
+        superseded = get_superseded_manifests(manifests_dir)
+        active_manifests = [m for m in manifest_files if m not in superseded]
+
+        if not active_manifests:
+            print("⚠️  No active manifest files found")
+            sys.exit(0)
+
+        if superseded and not quiet:
+            print(f"⏭️  Skipping {len(superseded)} superseded manifest(s)")
+
+    total_passed = 0
+    total_failed = 0
+    total_commands = 0
+    manifests_with_failures = 0
+    manifests_fully_passed = 0
+
+    for manifest_file in active_manifests:
+        try:
+            with open(manifest_file, "r") as f:
+                manifest_data = json.load(f)
+
+            # Validate version
+            try:
+                validate_manifest_version(manifest_data, manifest_file.name)
+            except ValueError as e:
+                if not quiet:
+                    print(f"\n⚠️  {manifest_file.name}: {e}")
+                continue
+
+            validation_commands = normalize_validation_commands(manifest_data)
+            if not validation_commands:
+                continue
+
+            if not quiet:
+                print(
+                    f"\n📋 {manifest_file.name}: Running {len(validation_commands)} validation command(s)"
+                )
+
+            passed, failed, total = execute_validation_commands(
+                manifest_file, manifest_data, timeout, verbose, project_root
+            )
+
+            total_passed += passed
+            total_failed += failed
+            total_commands += total
+
+            if failed > 0:
+                manifests_with_failures += 1
+                if fail_fast:
+                    print("\n❌ Stopping due to failure (--fail-fast)")
+                    sys.exit(1)
+            else:
+                manifests_fully_passed += 1
+
+        except json.JSONDecodeError as e:
+            if not quiet:
+                print(f"\n⚠️  {manifest_file.name}: Invalid JSON - {e}")
+            continue
+        except Exception as e:
+            if not quiet:
+                print(f"\n⚠️  {manifest_file.name}: Error - {e}")
+            continue
+
+    # Print summary
+    if total_commands > 0:
+        percentage = (total_passed / total_commands * 100) if total_commands > 0 else 0
+        print(
+            f"\n📊 Summary: {total_passed}/{total_commands} validation commands passed ({percentage:.1f}%)"
+        )
+        if not quiet:
+            print(f"   ✅ {manifests_fully_passed} manifest(s) fully passed")
+            if manifests_with_failures > 0:
+                print(f"   ❌ {manifests_with_failures} manifest(s) had failures")
+    else:
+        print("\n⚠️  No validation commands found in manifests")
+
+    # Exit with appropriate code
+    if total_failed > 0:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+def main() -> None:
+    """Main CLI entry point for maid test command."""
+    parser = argparse.ArgumentParser(
+        description="Run validation commands from all non-superseded manifests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Run all validation commands
+  %(prog)s
+
+  # Run validation commands for a single manifest
+  %(prog)s --manifest task-021-maid-test-command.manifest.json
+
+  # Use custom manifest directory
+  %(prog)s --manifest-dir my-manifests
+
+  # Stop on first failure
+  %(prog)s --fail-fast
+
+  # Show detailed output
+  %(prog)s --verbose
+
+  # Only show summary
+  %(prog)s --quiet
+        """,
+    )
+
+    parser.add_argument(
+        "--manifest",
+        "-m",
+        help="Run validation commands for a single manifest (filename relative to manifest-dir or absolute path)",
+    )
+
+    parser.add_argument(
+        "--manifest-dir",
+        default="manifests",
+        help="Directory containing manifests (default: manifests)",
+    )
+
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop execution on first failure",
+    )
+
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show detailed command output",
+    )
+
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Only show summary (suppress per-manifest output)",
+    )
+
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Command timeout in seconds (default: 300)",
+    )
+
+    args = parser.parse_args()
+
+    run_test(
+        manifest_dir=args.manifest_dir,
+        fail_fast=args.fail_fast,
+        verbose=args.verbose,
+        quiet=args.quiet,
+        timeout=args.timeout,
+        manifest_path=args.manifest,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/maid_runner/cli/validate.py
+++ b/maid_runner/cli/validate.py
@@ -205,6 +205,23 @@ def validate_behavioral_tests(
 
     # Manually validate each expected artifact is used across all test files
     for artifact in expected_items:
+        # Check for 'self' parameter before skipping artifacts
+        # This validation must occur even for private methods like __init__
+        if artifact.get("type") == "function":
+            parameters = artifact.get("args") or artifact.get("parameters", [])
+            if parameters:
+                for param in parameters:
+                    if param.get("name") == "self":
+                        from maid_runner.validators.manifest_validator import (
+                            AlignmentError,
+                        )
+
+                        raise AlignmentError(
+                            f"Manifest error: Parameter 'self' should not be explicitly declared "
+                            f"in method '{artifact.get('name')}'. In Python, 'self' is implicit for instance methods "
+                            f"and is not included in artifact declarations. Remove 'self' from the parameters list."
+                        )
+
         # Skip type-only artifacts in behavioral validation
         if should_skip_behavioral_validation(artifact):
             continue

--- a/maid_runner/cli/validate.py
+++ b/maid_runner/cli/validate.py
@@ -407,17 +407,21 @@ def _run_directory_validation(
         SystemExit: Exits with code 0 on success, 1 on failure
     """
     import os
-    from maid_runner.utils import get_superseded_manifests
+    from maid_runner.utils import (
+        get_superseded_manifests,
+        print_maid_not_enabled_message,
+        print_no_manifests_found_message,
+    )
 
     manifests_dir = Path(manifest_dir).resolve()
 
     if not manifests_dir.exists():
-        print(f"⚠️  Manifests directory not found: {manifest_dir}")
-        sys.exit(1)
+        print_maid_not_enabled_message(str(manifest_dir))
+        sys.exit(0)
 
     manifest_files = sorted(manifests_dir.glob("task-*.manifest.json"))
     if not manifest_files:
-        print("⚠️  No manifest files found")
+        print_no_manifests_found_message(str(manifest_dir))
         sys.exit(0)
 
     # Get superseded manifests and filter them out

--- a/maid_runner/cli/validate.py
+++ b/maid_runner/cli/validate.py
@@ -798,6 +798,17 @@ Validation Modes:
   implementation  - Validates that code DEFINES the expected artifacts (default)
   behavioral      - Validates that tests USE/CALL the expected artifacts
 
+File Tracking Analysis:
+  When using --use-manifest-chain in implementation mode, MAID Runner automatically
+  analyzes file tracking compliance across the codebase:
+
+  🔴 UNDECLARED - Files not in any manifest (high priority)
+  🟡 REGISTERED - Files tracked but incomplete compliance (medium priority)
+  ✓ TRACKED     - Files with full MAID compliance
+
+  This helps identify accountability gaps and ensures all source files are properly
+  documented in manifests.
+
 This enables MAID Phase 2 validation: manifest ↔ behavioral test alignment!
         """,
     )
@@ -818,7 +829,7 @@ This enables MAID Phase 2 validation: manifest ↔ behavioral test alignment!
     parser.add_argument(
         "--use-manifest-chain",
         action="store_true",
-        help="Use manifest chain to merge all related manifests",
+        help="Use manifest chain to merge all related manifests (enables file tracking analysis)",
     )
 
     parser.add_argument(

--- a/maid_runner/cli/validate.py
+++ b/maid_runner/cli/validate.py
@@ -382,6 +382,19 @@ def run_validation(
             # Implementation mode: Check implementation file exists and DEFINES artifacts
             if not Path(file_path).exists():
                 print(f"✗ Error: Target file not found: {file_path}")
+                print()
+                print(
+                    "⚠️  Hint: If you're validating a manifest before implementing the code (MAID Phase 2),"
+                )
+                print(
+                    "   you should use behavioral validation to check the test structure:"
+                )
+                print()
+                print(
+                    f"   uv run maid validate {manifest_path} --validation-mode behavioral"
+                )
+                print()
+                print("   Implementation validation requires the target file to exist.")
                 sys.exit(1)
 
             # Also run behavioral test validation if validation commands are present

--- a/maid_runner/utils.py
+++ b/maid_runner/utils.py
@@ -89,7 +89,7 @@ def normalize_validation_commands(manifest_data: dict) -> List[List[str]]:
 
 
 def get_superseded_manifests(manifests_dir: Path) -> set:
-    """Find all manifests that are superseded by snapshots.
+    """Find all manifests that are superseded by any other manifests.
 
     Args:
         manifests_dir: Path to the manifests directory
@@ -99,16 +99,16 @@ def get_superseded_manifests(manifests_dir: Path) -> set:
     """
     superseded = set()
 
-    # Find all snapshot manifests
-    snapshot_manifests = manifests_dir.glob("task-*-snapshot-*.manifest.json")
+    # Check ALL manifests for supersedes declarations (not just snapshots)
+    all_manifests = manifests_dir.glob("task-*.manifest.json")
 
-    for snapshot_path in snapshot_manifests:
+    for manifest_path in all_manifests:
         try:
-            with open(snapshot_path, "r") as f:
-                snapshot_data = json.load(f)
+            with open(manifest_path, "r") as f:
+                manifest_data = json.load(f)
 
-            # Get the supersedes list from the snapshot
-            supersedes_list = snapshot_data.get("supersedes", [])
+            # Get the supersedes list
+            supersedes_list = manifest_data.get("supersedes", [])
             for superseded_path_str in supersedes_list:
                 # Convert to Path and resolve relative to manifests_dir
                 superseded_path = Path(superseded_path_str)

--- a/maid_runner/utils.py
+++ b/maid_runner/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for MAID Runner."""
 
+import json
 import shlex
+from pathlib import Path
 from typing import List
 
 
@@ -84,3 +86,55 @@ def normalize_validation_commands(manifest_data: dict) -> List[List[str]]:
             return [validation_command]
 
     return []
+
+
+def get_superseded_manifests(manifests_dir: Path) -> set:
+    """Find all manifests that are superseded by snapshots.
+
+    Args:
+        manifests_dir: Path to the manifests directory
+
+    Returns:
+        set: Set of manifest paths (as Path objects) that are superseded
+    """
+    superseded = set()
+
+    # Find all snapshot manifests
+    snapshot_manifests = manifests_dir.glob("task-*-snapshot-*.manifest.json")
+
+    for snapshot_path in snapshot_manifests:
+        try:
+            with open(snapshot_path, "r") as f:
+                snapshot_data = json.load(f)
+
+            # Get the supersedes list from the snapshot
+            supersedes_list = snapshot_data.get("supersedes", [])
+            for superseded_path_str in supersedes_list:
+                # Convert to Path and resolve relative to manifests_dir
+                superseded_path = Path(superseded_path_str)
+                if not superseded_path.is_absolute():
+                    # If path includes "manifests/", resolve from manifests_dir's parent
+                    if str(superseded_path).startswith("manifests/"):
+                        superseded_path = manifests_dir.parent / superseded_path
+                    else:
+                        # Resolve relative to manifests_dir
+                        superseded_path = manifests_dir / superseded_path
+
+                # Normalize to relative path from manifests_dir for comparison
+                try:
+                    resolved = superseded_path.resolve()
+                    # Get relative path from manifests_dir
+                    try:
+                        relative_path = resolved.relative_to(manifests_dir.resolve())
+                        superseded.add(manifests_dir / relative_path)
+                    except ValueError:
+                        # Path is outside manifests_dir, skip
+                        pass
+                except (OSError, ValueError):
+                    # Invalid path, skip
+                    pass
+        except (json.JSONDecodeError, IOError):
+            # Skip invalid manifests
+            continue
+
+    return superseded

--- a/maid_runner/utils.py
+++ b/maid_runner/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import shlex
+import sys
 from pathlib import Path
 from typing import List
 
@@ -138,3 +139,66 @@ def get_superseded_manifests(manifests_dir: Path) -> set:
             continue
 
     return superseded
+
+
+def print_maid_not_enabled_message(manifest_dir: str, use_stderr: bool = False) -> None:
+    """Print a friendly message when MAID manifests directory is not found.
+
+    Args:
+        manifest_dir: Path to the manifests directory that was not found
+        use_stderr: If True, print to stderr instead of stdout
+    """
+    output_stream = sys.stderr if use_stderr else sys.stdout
+    print(file=output_stream)
+    print("⚠️  This repository does not appear to be MAID-enabled.", file=output_stream)
+    print(file=output_stream)
+    print(
+        f"   The manifests directory was not found: {manifest_dir}", file=output_stream
+    )
+    print(file=output_stream)
+    print(
+        "   MAID (Manifest-driven AI Development) requires a 'manifests' directory",
+        file=output_stream,
+    )
+    print(
+        "   containing task manifest files (task-*.manifest.json).", file=output_stream
+    )
+    print(file=output_stream)
+    print("   To get started with MAID:", file=output_stream)
+    print(
+        "   - Create a 'manifests' directory in your project root", file=output_stream
+    )
+    print("   - Generate manifests using: maid snapshot <file.py>", file=output_stream)
+    print(
+        "   - Or create manifests manually following the MAID specification",
+        file=output_stream,
+    )
+    print(file=output_stream)
+
+
+def print_no_manifests_found_message(
+    manifest_dir: str, use_stderr: bool = False
+) -> None:
+    """Print a friendly message when no manifest files are found in the directory.
+
+    Args:
+        manifest_dir: Path to the manifests directory
+        use_stderr: If True, print to stderr instead of stdout
+    """
+    output_stream = sys.stderr if use_stderr else sys.stdout
+    print(file=output_stream)
+    print("⚠️  No manifest files found in this repository.", file=output_stream)
+    print(file=output_stream)
+    print(f"   The manifests directory exists: {manifest_dir}", file=output_stream)
+    print(
+        "   but it does not contain any task manifest files (task-*.manifest.json).",
+        file=output_stream,
+    )
+    print(file=output_stream)
+    print("   To create manifest files:", file=output_stream)
+    print("   - Generate manifests using: maid snapshot <file.py>", file=output_stream)
+    print(
+        "   - Or create manifests manually following the MAID specification",
+        file=output_stream,
+    )
+    print(file=output_stream)

--- a/maid_runner/validators/file_tracker.py
+++ b/maid_runner/validators/file_tracker.py
@@ -1,0 +1,268 @@
+# maid_runner/validators/file_tracker.py
+"""File tracking validation for MAID manifests.
+
+This module provides validation to detect:
+- UNDECLARED: Files not in any manifest (high priority)
+- REGISTERED: Files in manifest but incomplete compliance (medium priority)
+- TRACKED: Files with full MAID compliance (clean)
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+from typing_extensions import TypedDict
+
+
+# File status constants
+FILE_STATUS_UNDECLARED = "UNDECLARED"
+FILE_STATUS_REGISTERED = "REGISTERED"
+FILE_STATUS_TRACKED = "TRACKED"
+
+
+# Type definitions
+class FileInfo(TypedDict):
+    """Information about a tracked file."""
+
+    file: str
+    status: str
+    issues: List[str]
+    manifests: List[str]
+
+
+class FileTrackingAnalysis(TypedDict):
+    """Results of file tracking analysis."""
+
+    undeclared: List[FileInfo]
+    registered: List[FileInfo]
+    tracked: List[str]
+
+
+def find_source_files(root_dir: str, exclude_patterns: List[str]) -> Set[str]:
+    """Find all Python source files in a directory.
+
+    Args:
+        root_dir: Root directory to search
+        exclude_patterns: List of glob patterns to exclude
+
+    Returns:
+        Set of relative file paths
+    """
+    root_path = Path(root_dir)
+    source_files = set()
+
+    # Find all .py files
+    for py_file in root_path.rglob("*.py"):
+        relative_path = py_file.relative_to(root_path).as_posix()
+
+        # Check if file matches any exclude pattern
+        excluded = False
+        for pattern in exclude_patterns:
+            # Simple pattern matching (supports basic wildcards)
+            if _matches_pattern(relative_path, pattern):
+                excluded = True
+                break
+
+        if not excluded:
+            source_files.add(relative_path)
+
+    return source_files
+
+
+def _matches_pattern(file_path: str, pattern: str) -> bool:
+    """Check if a file path matches an exclude pattern.
+
+    Args:
+        file_path: Relative file path
+        pattern: Glob-like pattern (e.g., "**/__pycache__/**", ".venv/**")
+
+    Returns:
+        True if file matches pattern
+    """
+    # Handle common patterns
+    if pattern.startswith("**"):
+        # Pattern like "**/__pycache__/**"
+        inner = pattern.strip("*").strip("/")
+        return inner in file_path
+
+    if pattern.endswith("/**"):
+        # Pattern like ".venv/**"
+        prefix = pattern.rstrip("/**")
+        return file_path.startswith(prefix + "/") or file_path == prefix
+
+    # Exact match
+    return file_path == pattern
+
+
+def collect_tracked_files(manifest_chain: List[dict]) -> Dict[str, dict]:
+    """Collect all tracked files from manifest chain.
+
+    Args:
+        manifest_chain: List of manifests
+
+    Returns:
+        Dictionary mapping file paths to tracking information
+    """
+    tracked_files = {}
+
+    for manifest in manifest_chain:
+        manifest_goal = manifest.get("goal", "unknown")
+
+        # Collect from creatableFiles
+        for file_path in manifest.get("creatableFiles", []):
+            if file_path not in tracked_files:
+                tracked_files[file_path] = {
+                    "created": False,
+                    "edited": False,
+                    "readonly": False,
+                    "has_artifacts": False,
+                    "has_tests": False,
+                    "manifests": [],
+                }
+            tracked_files[file_path]["created"] = True
+            tracked_files[file_path]["manifests"].append(manifest_goal)
+
+        # Collect from editableFiles
+        for file_path in manifest.get("editableFiles", []):
+            if file_path not in tracked_files:
+                tracked_files[file_path] = {
+                    "created": False,
+                    "edited": False,
+                    "readonly": False,
+                    "has_artifacts": False,
+                    "has_tests": False,
+                    "manifests": [],
+                }
+            tracked_files[file_path]["edited"] = True
+            tracked_files[file_path]["manifests"].append(manifest_goal)
+
+        # Collect from readonlyFiles
+        for file_path in manifest.get("readonlyFiles", []):
+            if file_path not in tracked_files:
+                tracked_files[file_path] = {
+                    "created": False,
+                    "edited": False,
+                    "readonly": False,
+                    "has_artifacts": False,
+                    "has_tests": False,
+                    "manifests": [],
+                }
+            tracked_files[file_path]["readonly"] = True
+            tracked_files[file_path]["manifests"].append(manifest_goal)
+
+        # Check if this manifest has expectedArtifacts
+        expected_artifacts = manifest.get("expectedArtifacts", {})
+        if expected_artifacts:
+            artifact_file = expected_artifacts.get("file")
+            if artifact_file and artifact_file in tracked_files:
+                tracked_files[artifact_file]["has_artifacts"] = True
+
+        # Check if this manifest has validationCommand (implies tests)
+        if manifest.get("validationCommand") or manifest.get("validationCommands"):
+            # Mark files in creatableFiles/editableFiles as having tests
+            for file_path in manifest.get("creatableFiles", []) + manifest.get(
+                "editableFiles", []
+            ):
+                if file_path in tracked_files:
+                    tracked_files[file_path]["has_tests"] = True
+
+    return tracked_files
+
+
+def classify_file_status(file_path: str, tracked_info: Optional[dict]) -> tuple:
+    """Classify file status as UNDECLARED, REGISTERED, or TRACKED.
+
+    Args:
+        file_path: Path to the file
+        tracked_info: Tracking information from collect_tracked_files
+
+    Returns:
+        Tuple of (status, issues_list)
+    """
+    # UNDECLARED: Not in any manifest
+    if tracked_info is None:
+        return (FILE_STATUS_UNDECLARED, ["Not found in any manifest"])
+
+    # Check compliance issues
+    issues = []
+
+    # Issue: Only in readonlyFiles (no creation/edit record)
+    if (
+        tracked_info["readonly"]
+        and not tracked_info["created"]
+        and not tracked_info["edited"]
+    ):
+        issues.append("Only in readonlyFiles (no creation/edit record)")
+
+    # Issue: No artifact declarations
+    if (tracked_info["created"] or tracked_info["edited"]) and not tracked_info[
+        "has_artifacts"
+    ]:
+        issues.append("In creatableFiles/editableFiles but no expectedArtifacts")
+
+    # Issue: No behavioral tests
+    if tracked_info["has_artifacts"] and not tracked_info["has_tests"]:
+        issues.append("Has artifact declarations but no behavioral tests")
+
+    # TRACKED: Full compliance (no issues)
+    if len(issues) == 0:
+        return (FILE_STATUS_TRACKED, [])
+
+    # REGISTERED: Some tracking but incomplete
+    return (FILE_STATUS_REGISTERED, issues)
+
+
+def analyze_file_tracking(
+    manifest_chain: List[dict], source_root: str
+) -> FileTrackingAnalysis:
+    """Analyze file tracking across manifest chain.
+
+    Args:
+        manifest_chain: List of manifests in chronological order
+        source_root: Root directory containing source files
+
+    Returns:
+        FileTrackingAnalysis with categorized files
+    """
+    # Default exclude patterns
+    default_excludes = [
+        "**/__pycache__/**",
+        "**/*.pyc",
+        ".venv/**",
+        "venv/**",
+        ".git/**",
+        ".pytest_cache/**",
+        "**/.mypy_cache/**",
+        "**/.ruff_cache/**",
+    ]
+
+    # Find all source files
+    all_files = find_source_files(source_root, default_excludes)
+
+    # Collect tracked files from manifests
+    tracked_files = collect_tracked_files(manifest_chain)
+
+    # Classify each file
+    undeclared = []
+    registered = []
+    tracked = []
+
+    for file_path in sorted(all_files):
+        tracked_info = tracked_files.get(file_path)
+        status, issues = classify_file_status(file_path, tracked_info)
+
+        if status == FILE_STATUS_UNDECLARED:
+            undeclared.append(
+                {"file": file_path, "status": status, "issues": issues, "manifests": []}
+            )
+        elif status == FILE_STATUS_REGISTERED:
+            registered.append(
+                {
+                    "file": file_path,
+                    "status": status,
+                    "issues": issues,
+                    "manifests": tracked_info["manifests"],
+                }
+            )
+        elif status == FILE_STATUS_TRACKED:
+            tracked.append(file_path)
+
+    return {"undeclared": undeclared, "registered": registered, "tracked": tracked}

--- a/maid_runner/validators/manifest_validator.py
+++ b/maid_runner/validators/manifest_validator.py
@@ -610,6 +610,7 @@ class _ArtifactCollector(ast.NodeVisitor):
             "os",
             "sys",
             "re",
+            "enum",
             "jsonschema",
         )
         return node.module and not node.module.startswith(stdlib_modules)

--- a/maid_runner/validators/manifest_validator.py
+++ b/maid_runner/validators/manifest_validator.py
@@ -1310,6 +1310,18 @@ def _validate_function_artifact(
     parameters = artifact.get("args") or artifact.get("parameters", [])
     parent_class = artifact.get("class")
 
+    # Reject manifests that explicitly declare 'self' as a parameter
+    # In Python, 'self' is implicit for instance methods and not included in artifact declarations
+    if parameters:
+        for param in parameters:
+            param_name = param.get("name")
+            if param_name == "self":
+                raise AlignmentError(
+                    f"Manifest error: Parameter 'self' should not be explicitly declared "
+                    f"in method '{artifact_name}'. In Python, 'self' is implicit for instance methods "
+                    f"and is not included in artifact declarations. Remove 'self' from the parameters list."
+                )
+
     if validation_mode == _VALIDATION_MODE_BEHAVIORAL:
         _validate_function_behavioral(
             artifact_name, parameters, parent_class, artifact, collector

--- a/maid_runner/validators/manifest_validator.py
+++ b/maid_runner/validators/manifest_validator.py
@@ -1427,9 +1427,8 @@ def _validate_method_parameters(
     """Validate method parameters match expectations."""
     actual_parameters = collector.found_methods[class_name][method_name]
 
-    # Skip 'self' parameter for methods
-    if "self" in actual_parameters:
-        actual_parameters = [p for p in actual_parameters if p != "self"]
+    # Skip 'self' and 'cls' parameters for methods and classmethods
+    actual_parameters = [p for p in actual_parameters if p not in ("self", "cls")]
 
     expected_param_names = [p["name"] for p in parameters]
 

--- a/manifests/task-004-behavioral-test-integration.manifest.json
+++ b/manifests/task-004-behavioral-test-integration.manifest.json
@@ -41,11 +41,6 @@
         ],
         "returns": "None",
         "artifactKind": "type"
-      },
-      {
-        "type": "class",
-        "name": "AlignmentError",
-        "artifactKind": "type"
       }
     ]
   },

--- a/manifests/task-004-behavioral-test-integration.manifest.json
+++ b/manifests/task-004-behavioral-test-integration.manifest.json
@@ -37,7 +37,9 @@
           {"name": "manifest_path", "type": "str"},
           {"name": "validation_mode", "type": "str"},
           {"name": "use_manifest_chain", "type": "bool"},
-          {"name": "quiet", "type": "bool"}
+          {"name": "quiet", "type": "bool"},
+          {"name": "manifest_dir", "type": "Optional[str]"},
+          {"name": "skip_file_tracking", "type": "bool"}
         ],
         "returns": "None",
         "artifactKind": "type"

--- a/manifests/task-009-snapshot-manifest_validator.manifest.json
+++ b/manifests/task-009-snapshot-manifest_validator.manifest.json
@@ -333,6 +333,9 @@
         "parameters": [
           {
             "name": "manifest_paths"
+          },
+          {
+            "name": "target_file"
           }
         ]
       },

--- a/manifests/task-009-snapshot-manifest_validator.manifest.json
+++ b/manifests/task-009-snapshot-manifest_validator.manifest.json
@@ -637,6 +637,9 @@
           },
           {
             "name": "found_functions"
+          },
+          {
+            "name": "found_methods"
           }
         ]
       },

--- a/manifests/task-013-pypi-packaging.manifest.json
+++ b/manifests/task-013-pypi-packaging.manifest.json
@@ -21,11 +21,6 @@
       {
         "type": "attribute",
         "name": "__all__"
-      },
-      {
-        "type": "class",
-        "name": "AlignmentError",
-        "artifactKind": "type"
       }
     ]
   },

--- a/manifests/task-015-fix-enum-import-detection.manifest.json
+++ b/manifests/task-015-fix-enum-import-detection.manifest.json
@@ -1,0 +1,30 @@
+{
+  "goal": "Fix validator incorrectly detecting enum imports as local classes by adding 'enum' to stdlib_modules list",
+  "taskType": "edit",
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/validators/test_imports.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "class",
+        "name": "_ArtifactCollector",
+        "bases": ["ast.NodeVisitor"]
+      },
+      {
+        "type": "function",
+        "name": "_is_local_import",
+        "class": "_ArtifactCollector",
+        "args": [
+          {"name": "node"}
+        ]
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/validators/test_imports.py::test_enum_import_not_tracked_as_local_class", "-v"]
+}

--- a/manifests/task-016-detect-abc-usage-patterns.manifest.json
+++ b/manifests/task-016-detect-abc-usage-patterns.manifest.json
@@ -1,0 +1,38 @@
+{
+  "goal": "Enhance behavioral validator to detect abstract base class usage patterns (isinstance, issubclass, hasattr, base class inheritance)",
+  "taskType": "edit",
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/validators/test_abc_usage.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "class",
+        "name": "_ArtifactCollector",
+        "bases": ["ast.NodeVisitor"]
+      },
+      {
+        "type": "function",
+        "name": "visit_Call",
+        "class": "_ArtifactCollector",
+        "args": [
+          {"name": "node"}
+        ]
+      },
+      {
+        "type": "function",
+        "name": "visit_ClassDef",
+        "class": "_ArtifactCollector",
+        "args": [
+          {"name": "node"}
+        ]
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/validators/test_abc_usage.py", "-v"]
+}

--- a/manifests/task-017-fix-behavioral-validation-file-check.manifest.json
+++ b/manifests/task-017-fix-behavioral-validation-file-check.manifest.json
@@ -1,0 +1,16 @@
+{
+  "goal": "Fix behavioral validation to not require implementation file existence - only check test files exist for behavioral mode",
+  "taskType": "edit",
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/cli/validate.py"
+  ],
+  "readonlyFiles": [
+    "tests/cli/test_behavioral_validation_without_impl.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/validate.py",
+    "contains": []
+  },
+  "validationCommand": ["pytest", "tests/cli/test_behavioral_validation_without_impl.py", "-v"]
+}

--- a/manifests/task-020-refactor-superseded-utils.manifest.json
+++ b/manifests/task-020-refactor-superseded-utils.manifest.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "goal": "Refactor get_superseded_manifests() from scripts/ to maid_runner/utils.py for better reusability by CLI commands",
+  "taskType": "refactor",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/utils.py",
+    "scripts/run_manifest_validation_commands.py"
+  ],
+  "readonlyFiles": [
+    "scripts/get_superseded_manifests.py",
+    "tests/test_task_020_refactor_superseded_utils.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/utils.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "get_superseded_manifests",
+        "args": [
+          {
+            "name": "manifests_dir",
+            "type": "Path"
+          }
+        ],
+        "returns": "set"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_020_refactor_superseded_utils.py", "-v"]
+}

--- a/manifests/task-021-maid-test-command.manifest.json
+++ b/manifests/task-021-maid-test-command.manifest.json
@@ -1,0 +1,86 @@
+{
+  "version": "1",
+  "goal": "Implement 'maid test' CLI command to execute validation commands across all non-superseded manifests",
+  "taskType": "create",
+  "supersedes": [],
+  "creatableFiles": [
+    "maid_runner/cli/test.py"
+  ],
+  "editableFiles": [
+    "maid_runner/cli/main.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/utils.py",
+    "tests/test_task_021_maid_test_command.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/test.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "execute_validation_commands",
+        "args": [
+          {
+            "name": "manifest_path",
+            "type": "Path"
+          },
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          },
+          {
+            "name": "timeout",
+            "type": "int"
+          },
+          {
+            "name": "verbose",
+            "type": "bool"
+          },
+          {
+            "name": "project_root",
+            "type": "Path"
+          }
+        ],
+        "returns": "tuple"
+      },
+      {
+        "type": "function",
+        "name": "run_test",
+        "args": [
+          {
+            "name": "manifest_dir",
+            "type": "str"
+          },
+          {
+            "name": "fail_fast",
+            "type": "bool"
+          },
+          {
+            "name": "verbose",
+            "type": "bool"
+          },
+          {
+            "name": "quiet",
+            "type": "bool"
+          },
+          {
+            "name": "timeout",
+            "type": "int"
+          },
+          {
+            "name": "manifest_path",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "main",
+        "args": [],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_021_maid_test_command.py", "-v"]
+}

--- a/manifests/task-021-maid-test-command.manifest.json
+++ b/manifests/task-021-maid-test-command.manifest.json
@@ -69,7 +69,7 @@
           },
           {
             "name": "manifest_path",
-            "type": "str"
+            "type": "Optional[str]"
           }
         ],
         "returns": "None"

--- a/manifests/task-022-add-manifest-dir-to-validate.manifest.json
+++ b/manifests/task-022-add-manifest-dir-to-validate.manifest.json
@@ -37,6 +37,10 @@
           {
             "name": "manifest_dir",
             "type": "Optional[str]"
+          },
+          {
+            "name": "skip_file_tracking",
+            "type": "bool"
           }
         ],
         "returns": "None"

--- a/manifests/task-022-add-manifest-dir-to-validate.manifest.json
+++ b/manifests/task-022-add-manifest-dir-to-validate.manifest.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "goal": "Add --manifest-dir option to 'maid validate' command to validate all manifests in a directory",
+  "taskType": "edit",
+  "supersedes": ["manifests/task-004-behavioral-test-integration.manifest.json"],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/cli/validate.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/utils.py",
+    "tests/test_task_022_validate_manifest_dir.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/validate.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "run_validation",
+        "args": [
+          {
+            "name": "manifest_path",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          },
+          {
+            "name": "use_manifest_chain",
+            "type": "bool"
+          },
+          {
+            "name": "quiet",
+            "type": "bool"
+          },
+          {
+            "name": "manifest_dir",
+            "type": "Optional[str]"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "main",
+        "args": [],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_022_validate_manifest_dir.py", "-v"]
+}

--- a/manifests/task-023-fix-manifest-chain-artifact-filtering.manifest.json
+++ b/manifests/task-023-fix-manifest-chain-artifact-filtering.manifest.json
@@ -1,0 +1,36 @@
+{
+  "goal": "Fix manifest chain artifact merging to filter by target file - only merge artifacts where expectedArtifacts.file matches the file being validated",
+  "taskType": "edit",
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_023_fix_manifest_chain_artifact_filtering.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "_merge_expected_artifacts",
+        "args": [
+          {"name": "manifest_paths", "type": "List[str]"},
+          {"name": "target_file", "type": "str"}
+        ],
+        "returns": "List[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_expected_artifacts",
+        "args": [
+          {"name": "manifest_data", "type": "dict"},
+          {"name": "test_file_path", "type": "str"},
+          {"name": "use_manifest_chain", "type": "bool"}
+        ],
+        "returns": "List[dict]"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_023_fix_manifest_chain_artifact_filtering.py", "-v"]
+}

--- a/manifests/task-024-fix-import-vs-definition-tracking.manifest.json
+++ b/manifests/task-024-fix-import-vs-definition-tracking.manifest.json
@@ -1,0 +1,22 @@
+{
+  "goal": "Fix validator to distinguish between imported classes (dependencies) and defined classes (artifacts). Imports should not be added to found_classes.",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": ["maid_runner/validators/manifest_validator.py"],
+  "readonlyFiles": [
+    "tests/test_task_024_import_vs_definition.py",
+    "maid_runner/validators/schemas/manifest.schema.json"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "class",
+        "name": "_ArtifactCollector",
+        "description": "AST visitor that collects artifacts. Imports are tracked separately from definitions - only defined classes populate found_classes."
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_024_import_vs_definition.py", "-v"]
+}

--- a/manifests/task-025-fix-cls-parameter-filtering.manifest.json
+++ b/manifests/task-025-fix-cls-parameter-filtering.manifest.json
@@ -1,0 +1,29 @@
+{
+  "goal": "Fix validator to filter both 'self' and 'cls' parameters from method validation, allowing classmethods to validate correctly",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_025_fix_cls_parameter.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "_validate_method_parameters",
+        "args": [
+          {"name": "method_name", "type": "str"},
+          {"name": "parameters", "type": "List[dict]"},
+          {"name": "class_name", "type": "str"},
+          {"name": "collector", "type": "_ArtifactCollector"}
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_025_fix_cls_parameter.py", "-v"]
+}

--- a/manifests/task-026-detect-classmethod-calls-on-class.manifest.json
+++ b/manifests/task-026-detect-classmethod-calls-on-class.manifest.json
@@ -1,0 +1,26 @@
+{
+  "goal": "Fix validator to detect classmethod calls made directly on the class name (e.g., ConfigService.create_default())",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_026_detect_classmethod_calls.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "visit_Call",
+        "class": "_ArtifactCollector",
+        "args": [
+          {"name": "node"}
+        ]
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_026_detect_classmethod_calls.py", "-v"]
+}

--- a/manifests/task-027-validate-unexpected-methods.manifest.json
+++ b/manifests/task-027-validate-unexpected-methods.manifest.json
@@ -1,0 +1,39 @@
+{
+  "goal": "Add validation to detect undeclared public methods in classes (currently only checks classes and functions)",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [
+    "tests/validators/test_task_027_validate_unexpected_methods.py"
+  ],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [
+    "tests/validators/test_task_027_validate_unexpected_methods.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "_check_unexpected_artifacts",
+        "parameters": [
+          {"name": "expected_items", "type": "List[dict]"},
+          {"name": "collector", "type": "_ArtifactCollector"}
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_no_unexpected_artifacts",
+        "parameters": [
+          {"name": "expected_items"},
+          {"name": "found_classes"},
+          {"name": "found_functions"},
+          {"name": "found_methods"}
+        ]
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/validators/test_task_027_validate_unexpected_methods.py", "-v"]
+}

--- a/manifests/task-028-file-tracking-validation.manifest.json
+++ b/manifests/task-028-file-tracking-validation.manifest.json
@@ -1,0 +1,82 @@
+{
+  "goal": "Add file tracking validation to detect UNDECLARED files (not in manifests) and REGISTERED files (incomplete compliance)",
+  "taskType": "create",
+  "supersedes": [],
+  "creatableFiles": [
+    "maid_runner/validators/file_tracker.py"
+  ],
+  "editableFiles": [
+    "maid_runner/cli/validate.py"
+  ],
+  "readonlyFiles": [
+    "tests/validators/test_task_028_file_tracking.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/file_tracker.py",
+    "contains": [
+      {
+        "type": "attribute",
+        "name": "FILE_STATUS_UNDECLARED",
+        "artifactKind": "runtime"
+      },
+      {
+        "type": "attribute",
+        "name": "FILE_STATUS_REGISTERED",
+        "artifactKind": "runtime"
+      },
+      {
+        "type": "attribute",
+        "name": "FILE_STATUS_TRACKED",
+        "artifactKind": "runtime"
+      },
+      {
+        "type": "class",
+        "name": "FileInfo",
+        "bases": ["TypedDict"],
+        "artifactKind": "type"
+      },
+      {
+        "type": "class",
+        "name": "FileTrackingAnalysis",
+        "bases": ["TypedDict"],
+        "artifactKind": "type"
+      },
+      {
+        "type": "function",
+        "name": "find_source_files",
+        "parameters": [
+          {"name": "root_dir", "type": "str"},
+          {"name": "exclude_patterns", "type": "List[str]"}
+        ],
+        "returns": "Set[str]"
+      },
+      {
+        "type": "function",
+        "name": "collect_tracked_files",
+        "parameters": [
+          {"name": "manifest_chain", "type": "List[dict]"}
+        ],
+        "returns": "Dict[str, dict]"
+      },
+      {
+        "type": "function",
+        "name": "classify_file_status",
+        "parameters": [
+          {"name": "file_path", "type": "str"},
+          {"name": "tracked_info", "type": "Optional[dict]"}
+        ],
+        "returns": "tuple"
+      },
+      {
+        "type": "function",
+        "name": "analyze_file_tracking",
+        "parameters": [
+          {"name": "manifest_chain", "type": "List[dict]"},
+          {"name": "source_root", "type": "str"}
+        ],
+        "returns": "FileTrackingAnalysis"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/validators/test_task_028_file_tracking.py", "-v"]
+}

--- a/manifests/task-029-list-manifests-command.manifest.json
+++ b/manifests/task-029-list-manifests-command.manifest.json
@@ -1,0 +1,73 @@
+{
+  "goal": "Add CLI command to list manifests related to a given implementation file",
+  "taskType": "create",
+  "supersedes": [],
+  "creatableFiles": [
+    "maid_runner/cli/list_manifests.py"
+  ],
+  "editableFiles": [
+    "maid_runner/cli/main.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_029_list_manifests.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/list_manifests.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "run_list_manifests",
+        "args": [
+          {
+            "name": "file_path",
+            "type": "str"
+          },
+          {
+            "name": "manifest_dir",
+            "type": "str"
+          },
+          {
+            "name": "quiet",
+            "type": "bool"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_categorize_manifest_by_file",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          },
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_format_manifest_list_output",
+        "args": [
+          {
+            "name": "categorized_manifests",
+            "type": "dict"
+          },
+          {
+            "name": "file_path",
+            "type": "str"
+          },
+          {
+            "name": "quiet",
+            "type": "bool"
+          }
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_029_list_manifests.py", "-v"]
+}

--- a/manifests/task-030-user-friendly-error-messages.manifest.json
+++ b/manifests/task-030-user-friendly-error-messages.manifest.json
@@ -1,0 +1,52 @@
+{
+  "version": "1",
+  "goal": "Add user-friendly error messages for CLI commands when manifests directory or manifest files are not found",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/utils.py",
+    "maid_runner/cli/validate.py",
+    "maid_runner/cli/test.py",
+    "maid_runner/cli/list_manifests.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_030_user_friendly_error_messages.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/utils.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "print_maid_not_enabled_message",
+        "args": [
+          {
+            "name": "manifest_dir",
+            "type": "str"
+          },
+          {
+            "name": "use_stderr",
+            "type": "bool"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "print_no_manifests_found_message",
+        "args": [
+          {
+            "name": "manifest_dir",
+            "type": "str"
+          },
+          {
+            "name": "use_stderr",
+            "type": "bool"
+          }
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_030_user_friendly_error_messages.py", "-v"]
+}

--- a/manifests/task-031-init-command.manifest.json
+++ b/manifests/task-031-init-command.manifest.json
@@ -1,0 +1,69 @@
+{
+  "goal": "Add 'maid init' CLI command to initialize MAID methodology in existing repositories",
+  "taskType": "create",
+  "supersedes": [],
+  "creatableFiles": [
+    "maid_runner/cli/init.py"
+  ],
+  "editableFiles": [
+    "maid_runner/cli/main.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_031_init_command.py",
+    "maid_runner/__init__.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/init.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "run_init",
+        "args": [
+          {"name": "target_dir", "type": "str"},
+          {"name": "force", "type": "bool"}
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "create_directories",
+        "args": [
+          {"name": "target_dir", "type": "str"}
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "create_example_manifest",
+        "args": [
+          {"name": "target_dir", "type": "str"}
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "copy_maid_specs",
+        "args": [
+          {"name": "target_dir", "type": "str"}
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "generate_claude_md_content",
+        "args": [],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "handle_claude_md",
+        "args": [
+          {"name": "target_dir", "type": "str"},
+          {"name": "force", "type": "bool"}
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_031_init_command.py", "-v"]
+}

--- a/scripts/run_manifest_validation_commands.py
+++ b/scripts/run_manifest_validation_commands.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from maid_runner.utils import get_superseded_manifests
+
 
 def extract_validation_commands(manifest_path: Path):
     """Extract validation commands from a manifest file."""
@@ -21,23 +23,6 @@ def extract_validation_commands(manifest_path: Path):
     except KeyError as e:
         print(f"⚠️  Warning: Missing key in {manifest_path.name}: {e}", file=sys.stderr)
         return []
-
-
-def get_superseded_manifests(manifests_dir: Path) -> set:
-    """Find all manifests that are superseded by snapshots."""
-    import importlib.util
-    import sys
-
-    # Import the function from the other script
-    script_path = Path(__file__).parent / "get_superseded_manifests.py"
-    spec = importlib.util.spec_from_file_location(
-        "get_superseded_manifests", script_path
-    )
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["get_superseded_manifests"] = module
-    spec.loader.exec_module(module)
-
-    return module.get_superseded_manifests(manifests_dir)
 
 
 def run_validation_commands():

--- a/scripts/validate_all_manifests.py
+++ b/scripts/validate_all_manifests.py
@@ -11,19 +11,10 @@ from pathlib import Path
 
 
 def get_superseded_manifests(manifests_dir: Path):
-    """Find all manifests that are superseded by snapshots."""
-    import importlib.util
+    """Find all manifests that are superseded by other manifests."""
+    from maid_runner.utils import get_superseded_manifests as get_superseded
 
-    # Import the function from the other script
-    script_path = Path(__file__).parent / "get_superseded_manifests.py"
-    spec = importlib.util.spec_from_file_location(
-        "get_superseded_manifests", script_path
-    )
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["get_superseded_manifests"] = module
-    spec.loader.exec_module(module)
-
-    return module.get_superseded_manifests(manifests_dir)
+    return get_superseded(manifests_dir)
 
 
 def run_structural_validation(manifest_path: Path) -> bool:

--- a/tests/cli/test_behavioral_validation_without_impl.py
+++ b/tests/cli/test_behavioral_validation_without_impl.py
@@ -1,0 +1,199 @@
+"""Tests for behavioral validation without implementation file existing.
+
+Behavioral validation during the planning phase should:
+- NOT require the implementation file to exist
+- Check that test files exist instead
+- Validate that tests USE the declared artifacts
+
+Implementation validation should:
+- Require the implementation file to exist
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_behavioral_validation_succeeds_without_implementation_file(tmp_path: Path):
+    """Test that behavioral validation passes even when implementation doesn't exist."""
+    # Create a manifest for a non-existent implementation file
+    manifest = {
+        "goal": "Test behavioral validation without implementation",
+        "taskType": "create",
+        "creatableFiles": ["src/nonexistent_module.py"],
+        "readonlyFiles": ["tests/test_nonexistent.py"],
+        "expectedArtifacts": {
+            "file": "src/nonexistent_module.py",
+            "contains": [
+                {"type": "class", "name": "MyClass"},
+                {
+                    "type": "function",
+                    "name": "my_function",
+                    "class": "MyClass",
+                    "args": [],
+                },
+            ],
+        },
+        "validationCommand": ["pytest", "tests/test_nonexistent.py", "-v"],
+    }
+
+    manifest_file = tmp_path / "test-manifest.json"
+    manifest_file.write_text(json.dumps(manifest, indent=2))
+
+    # Create test file that USES the artifacts
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    test_file = test_dir / "test_nonexistent.py"
+    test_file.write_text(
+        """
+from src.nonexistent_module import MyClass
+
+def test_my_class():
+    obj = MyClass()
+    obj.my_function()
+"""
+    )
+
+    # The implementation file does NOT exist
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    # DO NOT create src/nonexistent_module.py
+
+    # Run behavioral validation - should PASS
+    result = subprocess.run(
+        ["maid", "validate", str(manifest_file), "--validation-mode", "behavioral"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed because we're only checking if tests USE the artifacts
+    assert (
+        result.returncode == 0
+    ), f"Behavioral validation should pass without implementation.\nStdout: {result.stdout}\nStderr: {result.stderr}"
+    assert "Behavioral test validation PASSED" in result.stdout
+
+
+def test_implementation_validation_fails_without_implementation_file(tmp_path: Path):
+    """Test that implementation validation fails when implementation doesn't exist."""
+    manifest = {
+        "goal": "Test implementation validation requires implementation",
+        "taskType": "create",
+        "creatableFiles": ["src/nonexistent_impl.py"],
+        "readonlyFiles": ["tests/test_nonexistent_impl.py"],
+        "expectedArtifacts": {
+            "file": "src/nonexistent_impl.py",
+            "contains": [{"type": "function", "name": "my_func", "args": []}],
+        },
+        "validationCommand": ["pytest", "tests/test_nonexistent_impl.py", "-v"],
+    }
+
+    manifest_file = tmp_path / "test-manifest.json"
+    manifest_file.write_text(json.dumps(manifest, indent=2))
+
+    # Create test file
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    test_file = test_dir / "test_nonexistent_impl.py"
+    test_file.write_text(
+        """
+from src.nonexistent_impl import my_func
+
+def test_my_func():
+    result = my_func()
+    assert result is not None
+"""
+    )
+
+    # The implementation file does NOT exist
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    # Run implementation validation - should FAIL
+    result = subprocess.run(
+        ["maid", "validate", str(manifest_file), "--validation-mode", "implementation"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should fail because implementation file doesn't exist
+    assert result.returncode != 0
+    assert (
+        "Target file not found" in result.stdout
+        or "Target file not found" in result.stderr
+    )
+
+
+def test_behavioral_validation_fails_when_test_file_missing(tmp_path: Path):
+    """Test that behavioral validation fails when test file doesn't exist."""
+    manifest = {
+        "goal": "Test behavioral validation requires test files",
+        "taskType": "create",
+        "creatableFiles": ["src/module.py"],
+        "readonlyFiles": ["tests/test_missing.py"],
+        "expectedArtifacts": {
+            "file": "src/module.py",
+            "contains": [{"type": "function", "name": "func", "args": []}],
+        },
+        "validationCommand": ["pytest", "tests/test_missing.py", "-v"],
+    }
+
+    manifest_file = tmp_path / "test-manifest.json"
+    manifest_file.write_text(json.dumps(manifest, indent=2))
+
+    # Create src directory but NO test file
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    # DO NOT create tests/test_missing.py
+
+    # Run behavioral validation - should FAIL
+    result = subprocess.run(
+        ["maid", "validate", str(manifest_file), "--validation-mode", "behavioral"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should fail because test file doesn't exist
+    assert result.returncode != 0
+    assert (
+        "test file" in result.stdout.lower()
+        or "test file" in result.stderr.lower()
+        or "not found" in result.stdout.lower()
+    )
+
+
+def test_default_mode_is_implementation(tmp_path: Path):
+    """Test that default validation mode (no --validation-mode flag) checks implementation."""
+    manifest = {
+        "goal": "Test default validation mode",
+        "taskType": "create",
+        "creatableFiles": ["src/default_test.py"],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "src/default_test.py",
+            "contains": [{"type": "function", "name": "test_func", "args": []}],
+        },
+        "validationCommand": [],
+    }
+
+    manifest_file = tmp_path / "test-manifest.json"
+    manifest_file.write_text(json.dumps(manifest, indent=2))
+
+    # Don't create implementation file
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    # Run validation without --validation-mode flag (default is implementation)
+    result = subprocess.run(
+        ["maid", "validate", str(manifest_file)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should fail because default mode is implementation and file doesn't exist
+    assert result.returncode != 0

--- a/tests/test_manifest_to_implementation_alignment.py
+++ b/tests/test_manifest_to_implementation_alignment.py
@@ -17,22 +17,22 @@ MANIFESTS_DIR = Path("manifests/")
 
 
 def get_superseded_manifests():
-    """Find all manifests that are superseded by snapshots.
+    """Find all manifests that are superseded by any other manifests.
 
     Returns:
-        set: Set of manifest paths that are superseded by snapshot manifests
+        set: Set of manifest paths that are superseded by other manifests
     """
     superseded = set()
 
-    # Find all snapshot manifests
-    snapshot_manifests = MANIFESTS_DIR.glob("task-*-snapshot-*.manifest.json")
+    # Check ALL manifests for supersedes declarations (not just snapshots)
+    all_manifests = MANIFESTS_DIR.glob("task-*.manifest.json")
 
-    for snapshot_path in snapshot_manifests:
-        with open(snapshot_path, "r") as f:
-            snapshot_data = json.load(f)
+    for manifest_path in all_manifests:
+        with open(manifest_path, "r") as f:
+            manifest_data = json.load(f)
 
-        # Get the supersedes list from the snapshot
-        supersedes_list = snapshot_data.get("supersedes", [])
+        # Get the supersedes list
+        supersedes_list = manifest_data.get("supersedes", [])
         for superseded_path in supersedes_list:
             # Convert to Path and add to set
             superseded.add(Path(superseded_path))
@@ -43,8 +43,8 @@ def get_superseded_manifests():
 def find_manifest_files():
     """Scans the manifests directory and returns a list of all task manifests.
 
-    Excludes manifests that are superseded by snapshots, as those are historical
-    records and may not match current implementation after refactoring.
+    Excludes manifests that are superseded by other manifests, as those are historical
+    records and may not match current implementation after being superseded.
     """
     all_manifests = sorted(MANIFESTS_DIR.glob("task-*.manifest.json"))
     superseded = get_superseded_manifests()

--- a/tests/test_task_020_refactor_superseded_utils.py
+++ b/tests/test_task_020_refactor_superseded_utils.py
@@ -1,0 +1,116 @@
+"""Behavioral tests for Task 020: Refactoring get_superseded_manifests() to utils.py"""
+
+import json
+from pathlib import Path
+
+
+def test_get_superseded_manifests_in_utils():
+    """Test that get_superseded_manifests() is importable from maid_runner.utils."""
+    from maid_runner.utils import get_superseded_manifests
+
+    # Verify function is importable
+    assert callable(get_superseded_manifests)
+
+
+def test_get_superseded_manifests_returns_set(tmp_path: Path):
+    """Test that get_superseded_manifests() returns a set."""
+    from maid_runner.utils import get_superseded_manifests
+
+    # Create a manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create a simple manifest (not superseded)
+    manifest = {"goal": "test", "taskType": "edit"}
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Call function
+    result = get_superseded_manifests(manifests_dir)
+
+    # Verify it returns a set
+    assert isinstance(result, set)
+
+
+def test_get_superseded_manifests_finds_superseded(tmp_path: Path):
+    """Test that get_superseded_manifests() correctly identifies superseded manifests."""
+    from maid_runner.utils import get_superseded_manifests
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create regular manifests
+    manifest1 = {"goal": "task 1", "taskType": "edit"}
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    manifest2 = {"goal": "task 2", "taskType": "edit"}
+    manifest2_file = manifests_dir / "task-002.manifest.json"
+    manifest2_file.write_text(json.dumps(manifest2))
+
+    # Create snapshot that supersedes task-001
+    snapshot = {
+        "goal": "snapshot",
+        "taskType": "snapshot",
+        "supersedes": ["manifests/task-001.manifest.json"],
+    }
+    snapshot_file = manifests_dir / "task-003-snapshot-v1.manifest.json"
+    snapshot_file.write_text(json.dumps(snapshot))
+
+    # Call function
+    result = get_superseded_manifests(manifests_dir)
+
+    # Verify task-001 is identified as superseded
+    superseded_names = {p.name for p in result}
+    assert "task-001.manifest.json" in superseded_names
+    assert "task-002.manifest.json" not in superseded_names
+
+
+def test_get_superseded_manifests_handles_empty_dir(tmp_path: Path):
+    """Test that get_superseded_manifests() handles empty directory gracefully."""
+    from maid_runner.utils import get_superseded_manifests
+
+    # Create empty manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Call function
+    result = get_superseded_manifests(manifests_dir)
+
+    # Should return empty set
+    assert result == set()
+
+
+def test_get_superseded_manifests_handles_no_supersedes(tmp_path: Path):
+    """Test that get_superseded_manifests() handles manifests without supersedes field."""
+    from maid_runner.utils import get_superseded_manifests
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create snapshot without supersedes field
+    snapshot = {"goal": "snapshot", "taskType": "snapshot"}
+    snapshot_file = manifests_dir / "task-001-snapshot-v1.manifest.json"
+    snapshot_file.write_text(json.dumps(snapshot))
+
+    # Call function
+    result = get_superseded_manifests(manifests_dir)
+
+    # Should return empty set
+    assert result == set()
+
+
+def test_run_manifest_validation_commands_script_uses_utils_import(tmp_path: Path):
+    """Test that run_manifest_validation_commands.py imports from utils correctly."""
+    # Read the script
+    script_path = Path("scripts/run_manifest_validation_commands.py")
+    script_content = script_path.read_text()
+
+    # Verify it imports from maid_runner.utils (not the hacky importlib way)
+    assert "from maid_runner.utils import get_superseded_manifests" in script_content
+
+    # Verify it doesn't use the old importlib.util pattern
+    assert "importlib.util.spec_from_file_location" not in script_content
+    assert 'spec_from_file_location("get_superseded_manifests"' not in script_content

--- a/tests/test_task_021_maid_test_command.py
+++ b/tests/test_task_021_maid_test_command.py
@@ -1,0 +1,563 @@
+"""Behavioral tests for Task 021: Implementing maid test command"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def test_run_test_function_is_importable():
+    """Test that run_test() is importable from maid_runner.cli.test."""
+    from maid_runner.cli.test import run_test
+
+    assert callable(run_test)
+
+
+def test_execute_validation_commands_is_importable():
+    """Test that execute_validation_commands() is importable."""
+    from maid_runner.cli.test import execute_validation_commands
+
+    assert callable(execute_validation_commands)
+
+
+def test_main_function_is_importable():
+    """Test that main() is importable from maid_runner.cli.test."""
+    from maid_runner.cli.test import main
+
+    assert callable(main)
+
+
+def test_maid_test_command_runs(tmp_path: Path):
+    """Test that 'maid test' command runs successfully with basic setup."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create a simple passing manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "edit",
+        "editableFiles": ["test.py"],
+        "validationCommand": ["echo", "test passed"],
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Run maid test
+    result = subprocess.run(
+        ["maid", "test", "--manifest-dir", str(manifests_dir)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed
+    assert result.returncode == 0
+    assert "task-001.manifest.json" in result.stdout
+
+
+def test_maid_test_skips_superseded_manifests(tmp_path: Path):
+    """Test that maid test skips manifests listed in supersedes field."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create regular manifest
+    manifest1 = {
+        "version": "1",
+        "goal": "task 1",
+        "taskType": "edit",
+        "editableFiles": ["test1.py"],
+        "validationCommand": ["echo", "test1"],
+    }
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    # Create snapshot that supersedes task-001
+    snapshot = {
+        "version": "1",
+        "goal": "snapshot",
+        "taskType": "snapshot",
+        "editableFiles": ["test1.py"],
+        "supersedes": ["manifests/task-001.manifest.json"],
+        "validationCommand": ["echo", "snapshot"],
+    }
+    snapshot_file = manifests_dir / "task-002-snapshot-v1.manifest.json"
+    snapshot_file.write_text(json.dumps(snapshot))
+
+    # Run maid test
+    result = subprocess.run(
+        ["maid", "test", "--manifest-dir", str(manifests_dir)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed and show skipped count
+    assert result.returncode == 0
+    assert "Skipping" in result.stdout and "superseded" in result.stdout
+    # task-001 should not run, only snapshot should run
+    assert "task-002-snapshot-v1.manifest.json" in result.stdout
+
+
+def test_execute_validation_commands_returns_tuple(tmp_path: Path):
+    """Test that execute_validation_commands() returns a tuple with pass/fail counts."""
+    from maid_runner.cli.test import execute_validation_commands
+
+    # Create a manifest with validation command
+    manifest_data = {"validationCommand": ["echo", "test"]}
+    manifest_path = tmp_path / "test.manifest.json"
+
+    # Execute validation commands
+    result = execute_validation_commands(
+        manifest_path=manifest_path,
+        manifest_data=manifest_data,
+        timeout=300,
+        verbose=False,
+        project_root=tmp_path,
+    )
+
+    # Should return a tuple (passed, failed, total)
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    passed, failed, total = result
+    assert passed + failed == total
+
+
+def test_execute_validation_commands_with_passing_command(tmp_path: Path):
+    """Test that execute_validation_commands() correctly reports passing commands."""
+    from maid_runner.cli.test import execute_validation_commands
+
+    # Create a manifest with passing command
+    manifest_data = {"validationCommand": ["echo", "success"]}
+    manifest_path = tmp_path / "test.manifest.json"
+
+    # Execute validation commands
+    passed, failed, total = execute_validation_commands(
+        manifest_path=manifest_path,
+        manifest_data=manifest_data,
+        timeout=300,
+        verbose=False,
+        project_root=tmp_path,
+    )
+
+    # Should have 1 passed, 0 failed
+    assert passed == 1
+    assert failed == 0
+    assert total == 1
+
+
+def test_execute_validation_commands_with_failing_command(tmp_path: Path):
+    """Test that execute_validation_commands() correctly reports failing commands."""
+    from maid_runner.cli.test import execute_validation_commands
+
+    # Create a manifest with failing command
+    manifest_data = {"validationCommand": ["false"]}  # 'false' command always exits 1
+    manifest_path = tmp_path / "test.manifest.json"
+
+    # Execute validation commands
+    passed, failed, total = execute_validation_commands(
+        manifest_path=manifest_path,
+        manifest_data=manifest_data,
+        timeout=300,
+        verbose=False,
+        project_root=tmp_path,
+    )
+
+    # Should have 0 passed, 1 failed
+    assert passed == 0
+    assert failed == 1
+    assert total == 1
+
+
+def test_maid_test_fail_fast_stops_on_failure(tmp_path: Path):
+    """Test that --fail-fast flag stops execution on first failure."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create failing manifest
+    manifest1 = {
+        "version": "1",
+        "goal": "failing task",
+        "taskType": "edit",
+        "editableFiles": ["test1.py"],
+        "validationCommand": ["false"],
+    }
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    # Create second manifest (should not run)
+    manifest2 = {
+        "version": "1",
+        "goal": "second task",
+        "taskType": "edit",
+        "editableFiles": ["test2.py"],
+        "validationCommand": ["echo", "should not run"],
+    }
+    manifest2_file = manifests_dir / "task-002.manifest.json"
+    manifest2_file.write_text(json.dumps(manifest2))
+
+    # Run with --fail-fast
+    result = subprocess.run(
+        ["maid", "test", "--manifest-dir", str(manifests_dir), "--fail-fast"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should fail (exit code 1)
+    assert result.returncode == 1
+    # Should mention failure
+    assert "FAILED" in result.stdout or "failed" in result.stdout.lower()
+
+
+def test_maid_test_handles_empty_manifests_dir(tmp_path: Path):
+    """Test that maid test handles empty manifests directory gracefully."""
+    # Create empty manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Run maid test
+    result = subprocess.run(
+        ["maid", "test", "--manifest-dir", str(manifests_dir)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed (exit 0) with a message about no manifests
+    assert result.returncode == 0
+    assert "No manifest files found" in result.stdout or "No active" in result.stdout
+
+
+def test_execute_validation_commands_handles_enhanced_format(tmp_path: Path):
+    """Test that execute_validation_commands() handles enhanced validationCommands format."""
+    from maid_runner.cli.test import execute_validation_commands
+
+    # Create a manifest with enhanced format (array of arrays)
+    manifest_data = {"validationCommands": [["echo", "test1"], ["echo", "test2"]]}
+    manifest_path = tmp_path / "test.manifest.json"
+
+    # Execute validation commands
+    passed, failed, total = execute_validation_commands(
+        manifest_path=manifest_path,
+        manifest_data=manifest_data,
+        timeout=300,
+        verbose=False,
+        project_root=tmp_path,
+    )
+
+    # Should have 2 passed commands
+    assert passed == 2
+    assert failed == 0
+    assert total == 2
+
+
+def test_maid_test_shows_summary(tmp_path: Path):
+    """Test that maid test shows a summary of results."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create passing manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "edit",
+        "editableFiles": ["test.py"],
+        "validationCommand": ["echo", "test"],
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Run maid test
+    result = subprocess.run(
+        ["maid", "test", "--manifest-dir", str(manifests_dir)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should show summary
+    assert result.returncode == 0
+    assert "Summary" in result.stdout or "passed" in result.stdout.lower()
+
+
+def test_run_test_function_with_valid_manifest_dir(tmp_path: Path, capsys):
+    """Test that run_test() function executes correctly with valid manifest directory."""
+    from maid_runner.cli.test import run_test
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create passing manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "edit",
+        "editableFiles": ["test.py"],
+        "validationCommand": ["echo", "test passed"],
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Change to tmp directory
+    import os
+
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+
+        # Call run_test function - it should exit with 0 on success
+        with pytest.raises(SystemExit) as exc_info:
+            run_test(
+                manifest_dir=str(manifests_dir),
+                fail_fast=False,
+                verbose=False,
+                quiet=False,
+                timeout=300,
+                manifest_path=None,
+            )
+
+        # Should exit with code 0 (success)
+        assert exc_info.value.code == 0
+
+        # Capture output
+        captured = capsys.readouterr()
+
+        # Should show manifest name
+        assert "task-001.manifest.json" in captured.out
+
+    finally:
+        os.chdir(original_dir)
+
+
+def test_run_test_function_with_fail_fast(tmp_path: Path, capsys):
+    """Test that run_test() respects fail_fast parameter."""
+    from maid_runner.cli.test import run_test
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create failing manifest
+    manifest = {
+        "version": "1",
+        "goal": "failing test",
+        "taskType": "edit",
+        "editableFiles": ["test.py"],
+        "validationCommand": ["false"],
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Change to tmp directory
+    import os
+
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+
+        # Call run_test with fail_fast=True
+        # This should raise SystemExit when a test fails
+        with pytest.raises(SystemExit):
+            run_test(
+                manifest_dir=str(manifests_dir),
+                fail_fast=True,
+                verbose=False,
+                quiet=False,
+                timeout=300,
+                manifest_path=None,
+            )
+
+    finally:
+        os.chdir(original_dir)
+
+
+def test_main_function_runs_as_cli_entry_point(tmp_path: Path, monkeypatch):
+    """Test that main() function works as CLI entry point."""
+    from maid_runner.cli.test import main
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create passing manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "edit",
+        "editableFiles": ["test.py"],
+        "validationCommand": ["echo", "test"],
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Change to tmp directory
+    import os
+    import sys
+
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+
+        # Mock sys.argv to pass arguments
+        # Note: main() in test.py is already at the test command level,
+        # so we don't pass "test" as an argument
+        monkeypatch.setattr(
+            sys, "argv", ["maid-test", "--manifest-dir", str(manifests_dir)]
+        )
+
+        # Call main function - it should exit with 0 on success
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        # Should exit with code 0 (success)
+        assert exc_info.value.code == 0
+
+    finally:
+        os.chdir(original_dir)
+
+
+def test_maid_test_single_manifest(tmp_path: Path):
+    """Test that maid test can run validation commands for a single manifest."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create two manifests
+    manifest1 = {
+        "version": "1",
+        "goal": "task 1",
+        "taskType": "edit",
+        "editableFiles": ["test1.py"],
+        "validationCommand": ["echo", "test1"],
+    }
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    manifest2 = {
+        "version": "1",
+        "goal": "task 2",
+        "taskType": "edit",
+        "editableFiles": ["test2.py"],
+        "validationCommand": ["echo", "test2"],
+    }
+    manifest2_file = manifests_dir / "task-002.manifest.json"
+    manifest2_file.write_text(json.dumps(manifest2))
+
+    # Run maid test with --manifest option
+    result = subprocess.run(
+        [
+            "maid",
+            "test",
+            "--manifest-dir",
+            str(manifests_dir),
+            "--manifest",
+            "task-001.manifest.json",
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed and only run task-001
+    assert result.returncode == 0
+    assert "task-001.manifest.json" in result.stdout
+    # task-002 should NOT be in output
+    assert "task-002.manifest.json" not in result.stdout
+    assert "1/1 validation commands passed" in result.stdout
+
+
+def test_run_test_with_single_manifest_path(tmp_path: Path, capsys):
+    """Test that run_test() respects manifest_path parameter."""
+    from maid_runner.cli.test import run_test
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create two manifests
+    manifest1 = {
+        "version": "1",
+        "goal": "task 1",
+        "taskType": "edit",
+        "editableFiles": ["test1.py"],
+        "validationCommand": ["echo", "only this one should run"],
+    }
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    manifest2 = {
+        "version": "1",
+        "goal": "task 2",
+        "taskType": "edit",
+        "editableFiles": ["test2.py"],
+        "validationCommand": ["echo", "this should not run"],
+    }
+    manifest2_file = manifests_dir / "task-002.manifest.json"
+    manifest2_file.write_text(json.dumps(manifest2))
+
+    # Change to tmp directory
+    import os
+
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+
+        # Call run_test with manifest_path
+        with pytest.raises(SystemExit) as exc_info:
+            run_test(
+                manifest_dir=str(manifests_dir),
+                fail_fast=False,
+                verbose=False,
+                quiet=False,
+                timeout=300,
+                manifest_path="task-001.manifest.json",
+            )
+
+        # Should exit with code 0 (success)
+        assert exc_info.value.code == 0
+
+        # Capture output
+        captured = capsys.readouterr()
+
+        # Should only show task-001
+        assert "task-001.manifest.json" in captured.out
+        assert "only this one should run" in captured.out
+        # task-002 should NOT be in output
+        assert "task-002.manifest.json" not in captured.out
+        assert "this should not run" not in captured.out
+
+    finally:
+        os.chdir(original_dir)
+
+
+def test_maid_test_single_manifest_not_found(tmp_path: Path):
+    """Test that maid test handles non-existent single manifest gracefully."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Run maid test with non-existent manifest
+    result = subprocess.run(
+        [
+            "maid",
+            "test",
+            "--manifest-dir",
+            str(manifests_dir),
+            "--manifest",
+            "task-999.manifest.json",
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should fail with exit code 1
+    assert result.returncode == 1
+    assert "Manifest file not found" in result.stdout

--- a/tests/test_task_022_validate_manifest_dir.py
+++ b/tests/test_task_022_validate_manifest_dir.py
@@ -1,0 +1,309 @@
+"""Behavioral tests for Task 022: Adding --manifest-dir option to maid validate command"""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_run_validation_accepts_manifest_dir_parameter():
+    """Test that run_validation() accepts manifest_dir parameter."""
+    from maid_runner.cli.validate import run_validation
+
+    # Verify function signature
+    import inspect
+
+    sig = inspect.signature(run_validation)
+    assert "manifest_dir" in sig.parameters
+
+
+def test_maid_validate_with_manifest_dir_flag(tmp_path: Path):
+    """Test that 'maid validate --manifest-dir' validates all manifests."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def hello():\n    pass\n")
+
+    # Create a simple passing manifest
+    manifest1 = {
+        "version": "1",
+        "goal": "test 1",
+        "taskType": "create",
+        "creatableFiles": ["test.py"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+    }
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    # Run maid validate with --manifest-dir
+    result = subprocess.run(
+        ["maid", "validate", "--manifest-dir", str(manifests_dir), "--quiet"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed
+    assert result.returncode == 0
+    # Should validate at least one manifest
+    assert "1/1" in result.stdout or "100" in result.stdout
+
+
+def test_maid_validate_manifest_dir_skips_superseded(tmp_path: Path):
+    """Test that --manifest-dir skips superseded manifests."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def hello():\n    pass\n")
+
+    # Create regular manifest
+    manifest1 = {
+        "version": "1",
+        "goal": "task 1",
+        "taskType": "create",
+        "creatableFiles": ["test.py"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+    }
+    manifest1_file = manifests_dir / "task-001.manifest.json"
+    manifest1_file.write_text(json.dumps(manifest1))
+
+    # Create snapshot that supersedes task-001
+    snapshot = {
+        "version": "1",
+        "goal": "snapshot",
+        "taskType": "snapshot",
+        "editableFiles": ["test.py"],
+        "supersedes": ["manifests/task-001.manifest.json"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+        "validationCommand": ["echo", "test"],
+    }
+    snapshot_file = manifests_dir / "task-002-snapshot-v1.manifest.json"
+    snapshot_file.write_text(json.dumps(snapshot))
+
+    # Run maid validate with --manifest-dir
+    result = subprocess.run(
+        ["maid", "validate", "--manifest-dir", str(manifests_dir), "--quiet"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed and show only 1 manifest validated (snapshot, not task-001)
+    assert result.returncode == 0
+
+
+def test_maid_validate_with_single_manifest_still_works(tmp_path: Path):
+    """Test that single manifest validation still works (backward compatibility)."""
+    # Create test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def hello():\n    pass\n")
+
+    # Create a simple manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "create",
+        "creatableFiles": ["test.py"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+    }
+    manifest_file = tmp_path / "test.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Run maid validate with single manifest (no --manifest-dir)
+    result = subprocess.run(
+        ["maid", "validate", str(manifest_file), "--quiet"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should succeed
+    assert result.returncode == 0
+
+
+def test_run_validation_with_manifest_dir_parameter(tmp_path: Path):
+    """Test run_validation() function with manifest_dir parameter."""
+    from maid_runner.cli.validate import run_validation
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def hello():\n    pass\n")
+
+    # Create a simple manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "create",
+        "creatableFiles": ["test.py"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Change to tmp directory
+    import os
+
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+
+        # Call run_validation with manifest_dir - should exit with 0
+        import pytest
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_validation(
+                manifest_path=None,
+                validation_mode="implementation",
+                use_manifest_chain=False,
+                quiet=True,
+                manifest_dir=str(manifests_dir),
+            )
+
+        # Should exit with code 0 (success)
+        assert exc_info.value.code == 0
+
+    finally:
+        os.chdir(original_dir)
+
+
+def test_maid_validate_manifest_dir_shows_summary(tmp_path: Path):
+    """Test that --manifest-dir shows a summary of results."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def hello():\n    pass\n")
+
+    # Create manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "create",
+        "creatableFiles": ["test.py"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Run maid validate with --manifest-dir
+    result = subprocess.run(
+        ["maid", "validate", "--manifest-dir", str(manifests_dir)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should show summary
+    assert result.returncode == 0
+    assert "Summary" in result.stdout or "1/1" in result.stdout
+
+
+def test_maid_validate_cannot_use_both_manifest_and_dir(tmp_path: Path):
+    """Test that using both manifest path and --manifest-dir produces an error."""
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text('{"version": "1", "goal": "test"}')
+
+    # Try to use both
+    result = subprocess.run(
+        [
+            "maid",
+            "validate",
+            str(manifest_file),
+            "--manifest-dir",
+            str(manifests_dir),
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    # Should fail with error
+    assert result.returncode != 0
+    assert "error" in result.stderr.lower() or "error" in result.stdout.lower()
+
+
+def test_main_function_works_as_cli_entry_point(tmp_path: Path, monkeypatch):
+    """Test that main() function works as CLI entry point with --manifest-dir."""
+    from maid_runner.cli.validate import main
+
+    # Create manifests directory
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    # Create test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def hello():\n    pass\n")
+
+    # Create manifest
+    manifest = {
+        "version": "1",
+        "goal": "test",
+        "taskType": "create",
+        "creatableFiles": ["test.py"],
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "hello"}],
+        },
+    }
+    manifest_file = manifests_dir / "task-001.manifest.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    # Change to tmp directory
+    import os
+    import sys
+
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+
+        # Mock sys.argv to pass arguments
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["maid-validate", "--manifest-dir", str(manifests_dir), "--quiet"],
+        )
+
+        # Call main function - it should exit with 0 on success
+        import pytest
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        # Should exit with code 0 (success)
+        assert exc_info.value.code == 0
+
+    finally:
+        os.chdir(original_dir)

--- a/tests/test_task_023_fix_manifest_chain_artifact_filtering.py
+++ b/tests/test_task_023_fix_manifest_chain_artifact_filtering.py
@@ -1,0 +1,215 @@
+# tests/test_task_023_fix_manifest_chain_artifact_filtering.py
+"""
+Behavioral tests for Bug 1: Manifest chain artifact filtering by target file.
+
+Tests that _merge_expected_artifacts only includes artifacts where
+expectedArtifacts.file matches the target file being validated.
+"""
+import json
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from maid_runner.validators.manifest_validator import (
+    _merge_expected_artifacts,
+    _get_expected_artifacts,
+)
+
+
+def test_merge_filters_artifacts_by_target_file(tmp_path: Path):
+    """Test that _merge_expected_artifacts only includes artifacts for target file"""
+
+    # Create manifest 1: orchestrator.py with Developer class
+    manifest1 = {
+        "goal": "Create orchestrator",
+        "taskType": "create",
+        "creatableFiles": ["orchestrator.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "orchestrator.py",
+            "contains": [
+                {"type": "class", "name": "Developer"},
+                {"type": "function", "name": "run", "class": "Developer"},
+            ],
+        },
+        "validationCommand": ["echo", "test"],
+    }
+
+    # Create manifest 2: refiner.py with Refiner class
+    manifest2 = {
+        "goal": "Create refiner",
+        "taskType": "create",
+        "creatableFiles": ["refiner.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "refiner.py",
+            "contains": [
+                {"type": "class", "name": "Refiner"},
+                {"type": "function", "name": "refine", "class": "Refiner"},
+            ],
+        },
+        "validationCommand": ["echo", "test"],
+    }
+
+    # Create manifest 3: orchestrator.py again with additional method
+    manifest3 = {
+        "goal": "Add method to orchestrator",
+        "taskType": "edit",
+        "creatableFiles": [],
+        "editableFiles": ["orchestrator.py"],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "orchestrator.py",
+            "contains": [{"type": "function", "name": "execute", "class": "Developer"}],
+        },
+        "validationCommand": ["echo", "test"],
+    }
+
+    # Write manifests to temp files
+    manifest1_path = tmp_path / "task-001.manifest.json"
+    manifest2_path = tmp_path / "task-002.manifest.json"
+    manifest3_path = tmp_path / "task-003.manifest.json"
+
+    manifest1_path.write_text(json.dumps(manifest1))
+    manifest2_path.write_text(json.dumps(manifest2))
+    manifest3_path.write_text(json.dumps(manifest3))
+
+    # Test: Merge artifacts for orchestrator.py
+    manifest_paths = [str(manifest1_path), str(manifest2_path), str(manifest3_path)]
+    merged = _merge_expected_artifacts(manifest_paths, target_file="orchestrator.py")
+
+    # Should only include artifacts from manifest1 and manifest3 (orchestrator.py)
+    # Should NOT include artifacts from manifest2 (refiner.py)
+    artifact_names = {art["name"] for art in merged}
+
+    assert (
+        "Developer" in artifact_names
+    ), "Should include Developer class from manifest1"
+    assert "run" in artifact_names, "Should include run method from manifest1"
+    assert "execute" in artifact_names, "Should include execute method from manifest3"
+    assert (
+        "Refiner" not in artifact_names
+    ), "Should NOT include Refiner class from manifest2"
+    assert (
+        "refine" not in artifact_names
+    ), "Should NOT include refine method from manifest2"
+
+
+def test_merge_handles_empty_manifest_list(tmp_path: Path):
+    """Test that _merge_expected_artifacts handles empty manifest list"""
+    merged = _merge_expected_artifacts([], target_file="test.py")
+    assert merged == [], "Empty manifest list should return empty artifacts"
+
+
+def test_merge_handles_manifests_without_expected_artifacts(tmp_path: Path):
+    """Test that _merge_expected_artifacts handles manifests with no expectedArtifacts"""
+
+    manifest = {
+        "goal": "Test",
+        "taskType": "edit",
+        "creatableFiles": [],
+        "editableFiles": ["test.py"],
+        "readonlyFiles": [],
+        "expectedArtifacts": {"file": "test.py", "contains": []},
+        "validationCommand": ["echo", "test"],
+    }
+
+    manifest_path = tmp_path / "task-001.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    merged = _merge_expected_artifacts([str(manifest_path)], target_file="test.py")
+    assert merged == [], "Manifest with empty contains should return empty artifacts"
+
+
+def test_get_expected_artifacts_passes_target_file_to_merge(tmp_path: Path):
+    """Test that _get_expected_artifacts correctly passes target_file to _merge_expected_artifacts"""
+
+    # This test verifies the integration between _get_expected_artifacts and _merge_expected_artifacts
+    # We'll create a simple manifest and verify the function can be called
+    manifest_data = {
+        "taskType": "create",
+        "expectedArtifacts": {
+            "file": "test.py",
+            "contains": [{"type": "function", "name": "test_func"}],
+        },
+    }
+
+    # Without chain, should return artifacts from manifest_data directly
+    artifacts = _get_expected_artifacts(
+        manifest_data, "test.py", use_manifest_chain=False
+    )
+    assert len(artifacts) == 1
+    assert artifacts[0]["name"] == "test_func"
+
+
+def test_merge_overrides_earlier_artifact_definitions(tmp_path: Path):
+    """Test that later manifests override earlier ones for the same artifact"""
+
+    # Manifest 1: function with 1 parameter
+    manifest1 = {
+        "goal": "Create function",
+        "taskType": "create",
+        "creatableFiles": ["utils.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "utils.py",
+            "contains": [
+                {
+                    "type": "function",
+                    "name": "calculate",
+                    "args": [{"name": "x", "type": "int"}],
+                    "returns": "int",
+                }
+            ],
+        },
+        "validationCommand": ["echo", "test"],
+    }
+
+    # Manifest 2: same function with 2 parameters (updated signature)
+    manifest2 = {
+        "goal": "Update function signature",
+        "taskType": "edit",
+        "creatableFiles": [],
+        "editableFiles": ["utils.py"],
+        "readonlyFiles": [],
+        "expectedArtifacts": {
+            "file": "utils.py",
+            "contains": [
+                {
+                    "type": "function",
+                    "name": "calculate",
+                    "args": [
+                        {"name": "x", "type": "int"},
+                        {"name": "y", "type": "int"},
+                    ],
+                    "returns": "int",
+                }
+            ],
+        },
+        "validationCommand": ["echo", "test"],
+    }
+
+    manifest1_path = tmp_path / "task-001.manifest.json"
+    manifest2_path = tmp_path / "task-002.manifest.json"
+
+    manifest1_path.write_text(json.dumps(manifest1))
+    manifest2_path.write_text(json.dumps(manifest2))
+
+    # Merge in chronological order
+    manifest_paths = [str(manifest1_path), str(manifest2_path)]
+    merged = _merge_expected_artifacts(manifest_paths, target_file="utils.py")
+
+    # Should have only one calculate function (from manifest2)
+    calculate_artifacts = [art for art in merged if art["name"] == "calculate"]
+    assert len(calculate_artifacts) == 1, "Should have exactly one calculate artifact"
+
+    # Verify it's the updated version with 2 parameters
+    calc = calculate_artifacts[0]
+    assert len(calc["args"]) == 2, "Should have 2 parameters from manifest2"
+    assert calc["args"][0]["name"] == "x"
+    assert calc["args"][1]["name"] == "y"

--- a/tests/test_task_024_import_vs_definition.py
+++ b/tests/test_task_024_import_vs_definition.py
@@ -1,0 +1,347 @@
+"""
+Test Task-024: Validator distinction between imports and definitions.
+
+Tests the _ArtifactCollector class to ensure it properly distinguishes between:
+- Imported classes (dependencies) - should NOT be in found_classes
+- Defined classes (artifacts) - should BE in found_classes
+
+These tests USE the _ArtifactCollector class from maid_runner.validators.manifest_validator
+to verify that imports are not treated as defined artifacts.
+"""
+
+import ast
+
+from maid_runner.validators.manifest_validator import _ArtifactCollector
+
+
+def test_imported_classes_not_in_found_classes():
+    """Test that imported classes are NOT added to found_classes."""
+    # Create test code with imports but no class definitions
+    test_code = """
+from pathlib import Path
+from typing import Dict, Any
+from maid_runner.validators.manifest_validator import ManifestValidator
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Imported classes should NOT be in found_classes
+    assert (
+        "Path" not in collector.found_classes
+    ), "Path import wrongly added to found_classes"
+    assert (
+        "Dict" not in collector.found_classes
+    ), "Dict import wrongly added to found_classes"
+    assert (
+        "Any" not in collector.found_classes
+    ), "Any import wrongly added to found_classes"
+    assert (
+        "ManifestValidator" not in collector.found_classes
+    ), "ManifestValidator import wrongly added to found_classes"
+
+
+def test_defined_classes_in_found_classes():
+    """Test that defined classes ARE added to found_classes."""
+    # Create test code with class definitions
+    test_code = """
+class MyClass:
+    pass
+
+class AnotherClass:
+    def method(self):
+        pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Defined classes should BE in found_classes
+    assert (
+        "MyClass" in collector.found_classes
+    ), "MyClass definition not in found_classes"
+    assert (
+        "AnotherClass" in collector.found_classes
+    ), "AnotherClass definition not in found_classes"
+
+
+def test_mixed_imports_and_definitions():
+    """Test that imports and definitions are properly distinguished."""
+    # Create test code with both imports and definitions
+    test_code = """
+from pathlib import Path
+from typing import Dict, Any
+
+class ConfigLoader:
+    def __init__(self, path: Path):
+        self.path = path
+        self.config: Dict[str, Any] = {}
+
+class DataProcessor:
+    pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Imported classes should NOT be in found_classes
+    assert (
+        "Path" not in collector.found_classes
+    ), "Path import wrongly added to found_classes"
+    assert (
+        "Dict" not in collector.found_classes
+    ), "Dict import wrongly added to found_classes"
+    assert (
+        "Any" not in collector.found_classes
+    ), "Any import wrongly added to found_classes"
+
+    # Defined classes should BE in found_classes
+    assert (
+        "ConfigLoader" in collector.found_classes
+    ), "ConfigLoader definition not in found_classes"
+    assert (
+        "DataProcessor" in collector.found_classes
+    ), "DataProcessor definition not in found_classes"
+
+
+def test_local_module_imports_not_in_found_classes():
+    """Test that imports from local modules are not added to found_classes."""
+    # Create test code with local module imports
+    test_code = """
+from maid_runner.validators.manifest_validator import ManifestValidator, _ArtifactCollector
+from maid_runner.types import ManifestData, ArtifactSpec
+
+class MyValidator(ManifestValidator):
+    def custom_method(self):
+        pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Imported classes (even from local modules) should NOT be in found_classes
+    assert (
+        "ManifestValidator" not in collector.found_classes
+    ), "ManifestValidator import wrongly added"
+    assert (
+        "_ArtifactCollector" not in collector.found_classes
+    ), "_ArtifactCollector import wrongly added"
+    assert (
+        "ManifestData" not in collector.found_classes
+    ), "ManifestData import wrongly added"
+    assert (
+        "ArtifactSpec" not in collector.found_classes
+    ), "ArtifactSpec import wrongly added"
+
+    # Defined class (that inherits from imported class) should BE in found_classes
+    assert (
+        "MyValidator" in collector.found_classes
+    ), "MyValidator definition not in found_classes"
+
+
+def test_relative_imports_not_in_found_classes():
+    """Test that relative imports are not added to found_classes."""
+    # Create test code with relative imports
+    test_code = """
+from .validators import Validator
+from ..types import DataType
+from ...utils import Helper
+
+class MyClass:
+    pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Relative imports should NOT be in found_classes
+    assert (
+        "Validator" not in collector.found_classes
+    ), "Validator relative import wrongly added"
+    assert (
+        "DataType" not in collector.found_classes
+    ), "DataType relative import wrongly added"
+    assert (
+        "Helper" not in collector.found_classes
+    ), "Helper relative import wrongly added"
+
+    # Defined class should BE in found_classes
+    assert (
+        "MyClass" in collector.found_classes
+    ), "MyClass definition not in found_classes"
+
+
+def test_star_imports_not_crash():
+    """Test that star imports don't cause issues (they can't be tracked individually)."""
+    # Create test code with star imports
+    test_code = """
+from typing import *
+
+class MyClass:
+    pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Star imports can't be individually tracked, but shouldn't crash
+    # And shouldn't add spurious entries to found_classes
+    assert (
+        "MyClass" in collector.found_classes
+    ), "MyClass definition not in found_classes"
+
+
+def test_aliased_imports_not_in_found_classes():
+    """Test that aliased imports are not added to found_classes."""
+    # Create test code with aliased imports
+    test_code = """
+from pathlib import Path as FilePath
+from typing import Dict as Dictionary
+import json as JSON
+
+class Config:
+    pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Aliased imports should NOT be in found_classes (neither original nor alias names)
+    assert "Path" not in collector.found_classes, "Path import wrongly added"
+    assert "FilePath" not in collector.found_classes, "FilePath alias wrongly added"
+    assert "Dict" not in collector.found_classes, "Dict import wrongly added"
+    assert "Dictionary" not in collector.found_classes, "Dictionary alias wrongly added"
+
+    # Defined class should BE in found_classes
+    assert "Config" in collector.found_classes, "Config definition not in found_classes"
+
+
+def test_nested_class_definitions():
+    """Test that nested class definitions are properly detected."""
+    # Create test code with nested classes
+    test_code = """
+from typing import Any
+
+class OuterClass:
+    class InnerClass:
+        pass
+
+    class AnotherInner:
+        def method(self):
+            pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Imported type should NOT be in found_classes
+    assert "Any" not in collector.found_classes, "Any import wrongly added"
+
+    # All defined classes should BE in found_classes
+    assert (
+        "OuterClass" in collector.found_classes
+    ), "OuterClass definition not in found_classes"
+    assert (
+        "InnerClass" in collector.found_classes
+    ), "InnerClass definition not in found_classes"
+    assert (
+        "AnotherInner" in collector.found_classes
+    ), "AnotherInner definition not in found_classes"
+
+
+def test_class_with_imported_base():
+    """Test that class inheriting from imported class works correctly."""
+    # Create test code with inheritance from imported class
+    test_code = """
+from abc import ABC, abstractmethod
+
+class BaseValidator(ABC):
+    @abstractmethod
+    def validate(self):
+        pass
+
+class ConcreteValidator(BaseValidator):
+    def validate(self):
+        return True
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Imported classes should NOT be in found_classes
+    assert "ABC" not in collector.found_classes, "ABC import wrongly added"
+    assert (
+        "abstractmethod" not in collector.found_classes
+    ), "abstractmethod import wrongly added"
+
+    # Defined classes should BE in found_classes
+    assert (
+        "BaseValidator" in collector.found_classes
+    ), "BaseValidator definition not in found_classes"
+    assert (
+        "ConcreteValidator" in collector.found_classes
+    ), "ConcreteValidator definition not in found_classes"
+
+
+def test_empty_file_no_classes():
+    """Test that file with no classes has empty found_classes."""
+    # Create test code with no classes
+    test_code = """
+from typing import Dict
+import json
+
+def some_function():
+    pass
+
+variable = 42
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Should have no classes in found_classes
+    assert len(collector.found_classes) == 0, "found_classes should be empty"
+
+
+def test_regression_function_imports_not_added():
+    """Test that imported functions are also not added to found_classes."""
+    # Create test code with function imports (they shouldn't go to found_classes anyway)
+    test_code = """
+from pathlib import Path
+from typing import cast
+from os import path
+
+class MyClass:
+    pass
+"""
+
+    # Parse and analyze with _ArtifactCollector
+    tree = ast.parse(test_code)
+    collector = _ArtifactCollector()
+    collector.visit(tree)
+
+    # Only the defined class should be in found_classes
+    assert "MyClass" in collector.found_classes
+    assert (
+        len(collector.found_classes) == 1
+    ), f"found_classes should only contain MyClass, got: {collector.found_classes}"

--- a/tests/test_task_025_fix_cls_parameter.py
+++ b/tests/test_task_025_fix_cls_parameter.py
@@ -1,0 +1,245 @@
+"""
+Behavioral tests for Task-025: Fix cls parameter filtering in validator.
+
+These tests verify that the _validate_method_parameters function correctly
+filters both 'self' and 'cls' parameters from method validation, allowing
+classmethods to validate correctly without requiring 'cls' in the manifest.
+"""
+
+from pathlib import Path
+import pytest
+import tempfile
+
+# Import with fallback for Red phase testing
+try:
+    from maid_runner.validators.manifest_validator import validate_with_ast
+except ImportError as e:
+    # In Red phase, this function won't exist yet
+    pytest.skip(f"Implementation not ready: {e}", allow_module_level=True)
+
+
+class TestClsParameterFiltering:
+    """Test that cls parameter is properly filtered in classmethod validation."""
+
+    def test_classmethod_validates_without_cls_in_manifest(self):
+        """Test that classmethods validate successfully without cls in manifest args."""
+        # Create a temporary directory for test files
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create a Python file with a classmethod
+            code = '''
+class ConfigService:
+    """Service for managing configuration."""
+
+    @classmethod
+    def create_default(cls, name: str, value: int) -> "ConfigService":
+        """Create a default configuration."""
+        return cls()
+'''
+            test_file = tmp_path / "config_service.py"
+            test_file.write_text(code)
+
+            # Create manifest WITHOUT cls in the args (this should work after fix)
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(test_file),
+                    "contains": [
+                        {"type": "class", "name": "ConfigService"},
+                        {
+                            "type": "function",
+                            "name": "create_default",
+                            "class": "ConfigService",
+                            "args": [
+                                {"name": "name", "type": "str"},
+                                {"name": "value", "type": "int"},
+                            ],
+                            "returns": "ConfigService",
+                        },
+                    ],
+                }
+            }
+
+            # USE the validator - should pass after fix (cls is filtered)
+            validate_with_ast(manifest, str(test_file))
+
+    def test_regular_method_validates_without_self_in_manifest(self):
+        """Test that regular methods still validate successfully without self in manifest args."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create a Python file with a regular method
+            code = '''
+class UserService:
+    """Service for managing users."""
+
+    def create_user(self, username: str, email: str) -> dict:
+        """Create a new user."""
+        return {"username": username, "email": email}
+'''
+            test_file = tmp_path / "user_service.py"
+            test_file.write_text(code)
+
+            # Create manifest WITHOUT self in the args
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(test_file),
+                    "contains": [
+                        {"type": "class", "name": "UserService"},
+                        {
+                            "type": "function",
+                            "name": "create_user",
+                            "class": "UserService",
+                            "args": [
+                                {"name": "username", "type": "str"},
+                                {"name": "email", "type": "str"},
+                            ],
+                            "returns": "dict",
+                        },
+                    ],
+                }
+            }
+
+            # USE the validator - should pass (self is filtered)
+            validate_with_ast(manifest, str(test_file))
+
+    def test_mixed_methods_in_same_class(self):
+        """Test class with both regular methods and classmethods."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create a Python file with both method types
+            code = '''
+class DataService:
+    """Service for managing data."""
+
+    def process_data(self, data: str) -> str:
+        """Process some data."""
+        return data.upper()
+
+    @classmethod
+    def from_config(cls, config: dict) -> "DataService":
+        """Create service from config."""
+        return cls()
+
+    @staticmethod
+    def validate_input(value: str) -> bool:
+        """Validate input value."""
+        return bool(value)
+'''
+            test_file = tmp_path / "data_service.py"
+            test_file.write_text(code)
+
+            # Create manifest with all three method types
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(test_file),
+                    "contains": [
+                        {"type": "class", "name": "DataService"},
+                        {
+                            "type": "function",
+                            "name": "process_data",
+                            "class": "DataService",
+                            "args": [{"name": "data", "type": "str"}],
+                            "returns": "str",
+                        },
+                        {
+                            "type": "function",
+                            "name": "from_config",
+                            "class": "DataService",
+                            "args": [{"name": "config", "type": "dict"}],
+                            "returns": "DataService",
+                        },
+                        {
+                            "type": "function",
+                            "name": "validate_input",
+                            "class": "DataService",
+                            "args": [{"name": "value", "type": "str"}],
+                            "returns": "bool",
+                        },
+                    ],
+                }
+            }
+
+            # USE the validator - should pass for all method types
+            validate_with_ast(manifest, str(test_file))
+
+    def test_classmethod_with_no_additional_params(self):
+        """Test classmethod with only cls parameter (no other params)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create a Python file with a classmethod that only has cls
+            code = '''
+class SimpleService:
+    """Simple service."""
+
+    @classmethod
+    def create(cls) -> "SimpleService":
+        """Create a simple service instance."""
+        return cls()
+'''
+            test_file = tmp_path / "simple_service.py"
+            test_file.write_text(code)
+
+            # Create manifest with empty args list (no params after filtering cls)
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(test_file),
+                    "contains": [
+                        {"type": "class", "name": "SimpleService"},
+                        {
+                            "type": "function",
+                            "name": "create",
+                            "class": "SimpleService",
+                            "args": [],  # Empty - cls is filtered
+                            "returns": "SimpleService",
+                        },
+                    ],
+                }
+            }
+
+            # USE the validator - should pass with empty args
+            validate_with_ast(manifest, str(test_file))
+
+
+class TestBackwardCompatibility:
+    """Test that the fix doesn't break existing functionality."""
+
+    def test_self_parameter_still_filtered(self):
+        """Verify that self parameter filtering still works correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            code = '''
+class LegacyService:
+    """Legacy service class."""
+
+    def legacy_method(self, param1: str, param2: int) -> None:
+        """A legacy method."""
+        pass
+'''
+            test_file = tmp_path / "legacy.py"
+            test_file.write_text(code)
+
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(test_file),
+                    "contains": [
+                        {"type": "class", "name": "LegacyService"},
+                        {
+                            "type": "function",
+                            "name": "legacy_method",
+                            "class": "LegacyService",
+                            "args": [
+                                {"name": "param1", "type": "str"},
+                                {"name": "param2", "type": "int"},
+                            ],
+                            "returns": "None",
+                        },
+                    ],
+                }
+            }
+
+            # USE the validator - should still pass (self still filtered)
+            validate_with_ast(manifest, str(test_file))

--- a/tests/test_task_026_detect_classmethod_calls.py
+++ b/tests/test_task_026_detect_classmethod_calls.py
@@ -1,0 +1,255 @@
+"""
+Behavioral tests for Task-026: Detect classmethod calls on class name.
+
+These tests verify that the validator correctly detects classmethod calls made
+directly on the class name (e.g., ConfigService.create_default()) in behavioral
+test validation mode.
+"""
+
+from pathlib import Path
+import pytest
+import tempfile
+
+# Import with fallback for Red phase testing
+try:
+    from maid_runner.validators.manifest_validator import validate_with_ast
+except ImportError as e:
+    # In Red phase, this function won't exist yet
+    pytest.skip(f"Implementation not ready: {e}", allow_module_level=True)
+
+
+class TestClassmethodCallDetection:
+    """Test that classmethod calls on class names are properly detected."""
+
+    def test_detects_classmethod_call_on_class_name(self):
+        """Test that direct classmethod calls on class names are detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create implementation with a classmethod
+            impl_code = '''
+class ConfigService:
+    """Service for managing configuration."""
+
+    @classmethod
+    def create_default(cls, name: str):
+        """Create a default configuration."""
+        return cls()
+'''
+            impl_file = tmp_path / "config_service.py"
+            impl_file.write_text(impl_code)
+
+            # Create behavioral test that calls classmethod directly on class name
+            test_code = '''
+from config_service import ConfigService
+
+def test_create_default_config():
+    """Test creating a default configuration."""
+    # Call classmethod directly on class name
+    ConfigService.create_default("test")
+'''
+            test_file = tmp_path / "test_config.py"
+            test_file.write_text(test_code)
+
+            # Create manifest expecting the classmethod to be USED in tests
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(impl_file),
+                    "contains": [
+                        {"type": "class", "name": "ConfigService"},
+                        {
+                            "type": "function",
+                            "name": "create_default",
+                            "class": "ConfigService",
+                            "args": [{"name": "name", "type": "str"}],
+                        },
+                    ],
+                },
+                "validationCommand": ["pytest", str(test_file), "-v"],
+            }
+
+            # USE the validator in behavioral mode - should detect the classmethod call
+            validate_with_ast(
+                manifest,
+                str(test_file),
+                use_manifest_chain=False,
+                validation_mode="behavioral",
+            )
+
+    def test_detects_staticmethod_call_on_class_name(self):
+        """Test that staticmethod calls on class names are also detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create implementation with a staticmethod
+            impl_code = '''
+class DataValidator:
+    """Validator for data."""
+
+    @staticmethod
+    def validate_email(email: str):
+        """Validate an email address."""
+        return "@" in email
+'''
+            impl_file = tmp_path / "validator.py"
+            impl_file.write_text(impl_code)
+
+            # Create behavioral test that calls staticmethod directly on class name
+            test_code = '''
+from validator import DataValidator
+
+def test_validate_email():
+    """Test email validation."""
+    # Call staticmethod directly on class name
+    DataValidator.validate_email("test@example.com")
+'''
+            test_file = tmp_path / "test_validator.py"
+            test_file.write_text(test_code)
+
+            # Create manifest
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(impl_file),
+                    "contains": [
+                        {"type": "class", "name": "DataValidator"},
+                        {
+                            "type": "function",
+                            "name": "validate_email",
+                            "class": "DataValidator",
+                            "args": [{"name": "email", "type": "str"}],
+                        },
+                    ],
+                },
+                "validationCommand": ["pytest", str(test_file), "-v"],
+            }
+
+            # USE the validator - should detect the staticmethod call
+            validate_with_ast(
+                manifest,
+                str(test_file),
+                use_manifest_chain=False,
+                validation_mode="behavioral",
+            )
+
+    def test_detects_multiple_classmethod_calls(self):
+        """Test detecting multiple classmethod calls in the same test."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create implementation with multiple classmethods
+            impl_code = '''
+class UserFactory:
+    """Factory for creating users."""
+
+    @classmethod
+    def create_admin(cls, name: str):
+        """Create an admin user."""
+        return cls()
+
+    @classmethod
+    def create_guest(cls):
+        """Create a guest user."""
+        return cls()
+'''
+            impl_file = tmp_path / "user_factory.py"
+            impl_file.write_text(impl_code)
+
+            # Create behavioral test that calls multiple classmethods
+            test_code = '''
+from user_factory import UserFactory
+
+def test_user_creation():
+    """Test creating different types of users."""
+    UserFactory.create_admin("admin")
+    UserFactory.create_guest()
+'''
+            test_file = tmp_path / "test_users.py"
+            test_file.write_text(test_code)
+
+            # Create manifest
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(impl_file),
+                    "contains": [
+                        {"type": "class", "name": "UserFactory"},
+                        {
+                            "type": "function",
+                            "name": "create_admin",
+                            "class": "UserFactory",
+                            "args": [{"name": "name", "type": "str"}],
+                        },
+                        {
+                            "type": "function",
+                            "name": "create_guest",
+                            "class": "UserFactory",
+                            "args": [],
+                        },
+                    ],
+                },
+                "validationCommand": ["pytest", str(test_file), "-v"],
+            }
+
+            # USE the validator - should detect both classmethod calls
+            validate_with_ast(
+                manifest,
+                str(test_file),
+                use_manifest_chain=False,
+                validation_mode="behavioral",
+            )
+
+    def test_instance_methods_still_work(self):
+        """Test that regular instance method detection still works."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+
+            # Create implementation with regular instance method
+            impl_code = '''
+class Calculator:
+    """Simple calculator."""
+
+    def add(self, a: int, b: int):
+        """Add two numbers."""
+        return a + b
+'''
+            impl_file = tmp_path / "calculator.py"
+            impl_file.write_text(impl_code)
+
+            # Create behavioral test that uses instance method
+            test_code = '''
+from calculator import Calculator
+
+def test_addition():
+    """Test addition."""
+    calc = Calculator()
+    calc.add(2, 3)
+'''
+            test_file = tmp_path / "test_calculator.py"
+            test_file.write_text(test_code)
+
+            # Create manifest
+            manifest = {
+                "expectedArtifacts": {
+                    "file": str(impl_file),
+                    "contains": [
+                        {"type": "class", "name": "Calculator"},
+                        {
+                            "type": "function",
+                            "name": "add",
+                            "class": "Calculator",
+                            "args": [
+                                {"name": "a", "type": "int"},
+                                {"name": "b", "type": "int"},
+                            ],
+                        },
+                    ],
+                },
+                "validationCommand": ["pytest", str(test_file), "-v"],
+            }
+
+            # USE the validator - instance methods should still work
+            validate_with_ast(
+                manifest,
+                str(test_file),
+                use_manifest_chain=False,
+                validation_mode="behavioral",
+            )

--- a/tests/test_task_029_list_manifests.py
+++ b/tests/test_task_029_list_manifests.py
@@ -1,0 +1,328 @@
+"""Behavioral tests for Task-029: List manifests command.
+
+Tests the new CLI command that lists all manifests related to a given file,
+categorized by how the manifest references the file (created, edited, read).
+"""
+
+import json
+
+
+def test_run_list_manifests_exists():
+    """Test that run_list_manifests function exists and can be imported."""
+    from maid_runner.cli.list_manifests import run_list_manifests
+
+    assert callable(run_list_manifests)
+
+
+def test_run_list_manifests_signature():
+    """Test that run_list_manifests has the expected signature."""
+    from maid_runner.cli.list_manifests import run_list_manifests
+    import inspect
+
+    sig = inspect.signature(run_list_manifests)
+    params = list(sig.parameters.keys())
+
+    assert "file_path" in params
+    assert "manifest_dir" in params
+    assert "quiet" in params
+
+
+def test_categorize_manifest_by_file_exists():
+    """Test that _categorize_manifest_by_file helper function exists."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+
+    assert callable(_categorize_manifest_by_file)
+
+
+def test_categorize_manifest_by_file_signature():
+    """Test that _categorize_manifest_by_file has the expected signature."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+    import inspect
+
+    sig = inspect.signature(_categorize_manifest_by_file)
+    params = list(sig.parameters.keys())
+
+    assert "manifest_data" in params
+    assert "file_path" in params
+
+
+def test_categorize_manifest_by_file_creatable():
+    """Test categorization of file in creatableFiles."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+
+    manifest_data = {
+        "creatableFiles": ["foo.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+    }
+
+    category = _categorize_manifest_by_file(manifest_data, "foo.py")
+    assert category == "created"
+
+
+def test_categorize_manifest_by_file_editable():
+    """Test categorization of file in editableFiles."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+
+    manifest_data = {
+        "creatableFiles": [],
+        "editableFiles": ["bar.py"],
+        "readonlyFiles": [],
+    }
+
+    category = _categorize_manifest_by_file(manifest_data, "bar.py")
+    assert category == "edited"
+
+
+def test_categorize_manifest_by_file_readonly():
+    """Test categorization of file in readonlyFiles."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+
+    manifest_data = {
+        "creatableFiles": [],
+        "editableFiles": [],
+        "readonlyFiles": ["baz.py"],
+    }
+
+    category = _categorize_manifest_by_file(manifest_data, "baz.py")
+    assert category == "read"
+
+
+def test_categorize_manifest_by_file_not_found():
+    """Test categorization when file is not referenced."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+
+    manifest_data = {
+        "creatableFiles": [],
+        "editableFiles": [],
+        "readonlyFiles": [],
+    }
+
+    category = _categorize_manifest_by_file(manifest_data, "notfound.py")
+    assert category is None
+
+
+def test_categorize_manifest_by_file_priority():
+    """Test that created takes priority over edited over read."""
+    from maid_runner.cli.list_manifests import _categorize_manifest_by_file
+
+    # File in multiple categories - created should win
+    manifest_data = {
+        "creatableFiles": ["test.py"],
+        "editableFiles": ["test.py"],
+        "readonlyFiles": ["test.py"],
+    }
+
+    category = _categorize_manifest_by_file(manifest_data, "test.py")
+    assert category == "created"
+
+
+def test_format_manifest_list_output_exists():
+    """Test that _format_manifest_list_output helper function exists."""
+    from maid_runner.cli.list_manifests import _format_manifest_list_output
+
+    assert callable(_format_manifest_list_output)
+
+
+def test_format_manifest_list_output_signature():
+    """Test that _format_manifest_list_output has the expected signature."""
+    from maid_runner.cli.list_manifests import _format_manifest_list_output
+    import inspect
+
+    sig = inspect.signature(_format_manifest_list_output)
+    params = list(sig.parameters.keys())
+
+    assert "categorized_manifests" in params
+    assert "file_path" in params
+    assert "quiet" in params
+
+
+def test_format_manifest_list_output_with_data(capsys):
+    """Test that _format_manifest_list_output produces formatted output."""
+    from maid_runner.cli.list_manifests import _format_manifest_list_output
+
+    categorized = {
+        "created": ["task-001.manifest.json"],
+        "edited": ["task-002.manifest.json", "task-003.manifest.json"],
+        "read": ["task-004.manifest.json"],
+    }
+
+    _format_manifest_list_output(categorized, "test.py", quiet=False)
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Check that output contains the file path
+    assert "test.py" in output
+
+    # Check that output contains category labels
+    assert "created" in output.lower() or "creat" in output.lower()
+    assert "edited" in output.lower() or "edit" in output.lower()
+    assert "read" in output.lower()
+
+    # Check that manifest names appear
+    assert "task-001" in output
+    assert "task-002" in output
+    assert "task-003" in output
+    assert "task-004" in output
+
+
+def test_format_manifest_list_output_empty(capsys):
+    """Test output when no manifests reference the file."""
+    from maid_runner.cli.list_manifests import _format_manifest_list_output
+
+    categorized = {
+        "created": [],
+        "edited": [],
+        "read": [],
+    }
+
+    _format_manifest_list_output(categorized, "orphan.py", quiet=False)
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Should indicate no manifests found
+    assert "no manifest" in output.lower() or "not found" in output.lower()
+
+
+def test_run_list_manifests_with_temp_manifests(tmp_path, capsys):
+    """Test run_list_manifests with temporary manifest files."""
+    from maid_runner.cli.list_manifests import run_list_manifests
+
+    # Create a temporary manifest directory
+    manifest_dir = tmp_path / "manifests"
+    manifest_dir.mkdir()
+
+    # Create test manifests
+    manifest1 = {
+        "goal": "Create test.py",
+        "creatableFiles": ["test.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+    }
+
+    manifest2 = {
+        "goal": "Edit test.py",
+        "creatableFiles": [],
+        "editableFiles": ["test.py"],
+        "readonlyFiles": [],
+    }
+
+    manifest3 = {
+        "goal": "Read test.py",
+        "creatableFiles": [],
+        "editableFiles": [],
+        "readonlyFiles": ["test.py"],
+    }
+
+    # Write manifests
+    with open(manifest_dir / "task-001.manifest.json", "w") as f:
+        json.dump(manifest1, f)
+
+    with open(manifest_dir / "task-002.manifest.json", "w") as f:
+        json.dump(manifest2, f)
+
+    with open(manifest_dir / "task-003.manifest.json", "w") as f:
+        json.dump(manifest3, f)
+
+    # Run the command
+    run_list_manifests("test.py", str(manifest_dir), quiet=False)
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify output contains all manifest references
+    assert "task-001" in output
+    assert "task-002" in output
+    assert "task-003" in output
+
+
+def test_run_list_manifests_no_matches(tmp_path, capsys):
+    """Test run_list_manifests when file is not in any manifest."""
+    from maid_runner.cli.list_manifests import run_list_manifests
+
+    # Create a temporary manifest directory
+    manifest_dir = tmp_path / "manifests"
+    manifest_dir.mkdir()
+
+    # Create a manifest that doesn't reference our target file
+    manifest1 = {
+        "goal": "Create other.py",
+        "creatableFiles": ["other.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+    }
+
+    with open(manifest_dir / "task-001.manifest.json", "w") as f:
+        json.dump(manifest1, f)
+
+    # Run the command for a file not in any manifest
+    run_list_manifests("orphan.py", str(manifest_dir), quiet=False)
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Should indicate no manifests found
+    assert "no manifest" in output.lower() or "not found" in output.lower()
+
+
+def test_run_list_manifests_quiet_mode(tmp_path, capsys):
+    """Test run_list_manifests in quiet mode."""
+    from maid_runner.cli.list_manifests import run_list_manifests
+
+    # Create a temporary manifest directory
+    manifest_dir = tmp_path / "manifests"
+    manifest_dir.mkdir()
+
+    # Create a test manifest
+    manifest1 = {
+        "goal": "Create test.py",
+        "creatableFiles": ["test.py"],
+        "editableFiles": [],
+        "readonlyFiles": [],
+    }
+
+    with open(manifest_dir / "task-001.manifest.json", "w") as f:
+        json.dump(manifest1, f)
+
+    # Run in quiet mode
+    run_list_manifests("test.py", str(manifest_dir), quiet=True)
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # In quiet mode, output should be minimal (just manifest names, no decorative text)
+    # The exact behavior depends on implementation, but it should be less verbose
+    # At minimum, it should still show the manifest name
+    assert "task-001" in output
+
+
+def test_cli_integration_manifests_command():
+    """Test that the 'manifests' subcommand is registered in main CLI."""
+    import sys
+    from io import StringIO
+
+    from maid_runner.cli.main import main
+
+    # Capture help output to verify subcommand exists
+    old_stdout = sys.stdout
+    old_argv = sys.argv
+
+    try:
+        sys.stdout = StringIO()
+        sys.argv = ["maid", "--help"]
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        help_output = sys.stdout.getvalue()
+
+        # Verify 'manifests' subcommand is mentioned in help
+        assert "manifests" in help_output.lower()
+
+    finally:
+        sys.stdout = old_stdout
+        sys.argv = old_argv

--- a/tests/test_task_030_user_friendly_error_messages.py
+++ b/tests/test_task_030_user_friendly_error_messages.py
@@ -1,0 +1,109 @@
+"""Behavioral tests for task-030: User-friendly error messages.
+
+Tests verify that the error messaging functions work correctly and output
+the expected user-friendly messages when manifests directory or files are not found.
+"""
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+from maid_runner.utils import (
+    print_maid_not_enabled_message,
+    print_no_manifests_found_message,
+)
+
+
+def test_print_maid_not_enabled_message_stdout():
+    """Test print_maid_not_enabled_message outputs to stdout by default."""
+    manifest_dir = "/path/to/manifests"
+
+    # Capture stdout
+    f = io.StringIO()
+    with redirect_stdout(f):
+        print_maid_not_enabled_message(manifest_dir, use_stderr=False)
+
+    output = f.getvalue()
+
+    # Verify key messages are present
+    assert "This repository does not appear to be MAID-enabled" in output
+    assert manifest_dir in output
+    assert "manifests directory" in output.lower()
+    assert "maid snapshot" in output.lower()
+
+
+def test_print_maid_not_enabled_message_stderr():
+    """Test print_maid_not_enabled_message outputs to stderr when requested."""
+    manifest_dir = "/path/to/manifests"
+
+    # Capture stderr
+    f = io.StringIO()
+    with redirect_stderr(f):
+        print_maid_not_enabled_message(manifest_dir, use_stderr=True)
+
+    output = f.getvalue()
+
+    # Verify key messages are present
+    assert "This repository does not appear to be MAID-enabled" in output
+    assert manifest_dir in output
+    assert "manifests directory" in output.lower()
+
+
+def test_print_no_manifests_found_message_stdout():
+    """Test print_no_manifests_found_message outputs to stdout by default."""
+    manifest_dir = "/path/to/manifests"
+
+    # Capture stdout
+    f = io.StringIO()
+    with redirect_stdout(f):
+        print_no_manifests_found_message(manifest_dir, use_stderr=False)
+
+    output = f.getvalue()
+
+    # Verify key messages are present
+    assert "No manifest files found" in output
+    assert manifest_dir in output
+    assert "task-*.manifest.json" in output
+    assert "maid snapshot" in output.lower()
+
+
+def test_print_no_manifests_found_message_stderr():
+    """Test print_no_manifests_found_message outputs to stderr when requested."""
+    manifest_dir = "/path/to/manifests"
+
+    # Capture stderr
+    f = io.StringIO()
+    with redirect_stderr(f):
+        print_no_manifests_found_message(manifest_dir, use_stderr=True)
+
+    output = f.getvalue()
+
+    # Verify key messages are present
+    assert "No manifest files found" in output
+    assert manifest_dir in output
+    assert "task-*.manifest.json" in output
+
+
+def test_messages_contain_helpful_guidance():
+    """Test that both messages contain helpful guidance for users."""
+    manifest_dir = "/test/manifests"
+
+    # Test maid_not_enabled message
+    f1 = io.StringIO()
+    with redirect_stdout(f1):
+        print_maid_not_enabled_message(manifest_dir)
+    output1 = f1.getvalue()
+
+    # Should suggest creating manifests directory
+    assert "Create a 'manifests' directory" in output1 or "create" in output1.lower()
+
+    # Test no_manifests_found message
+    f2 = io.StringIO()
+    with redirect_stdout(f2):
+        print_no_manifests_found_message(manifest_dir)
+    output2 = f2.getvalue()
+
+    # Should suggest ways to create manifest files
+    assert "maid snapshot" in output2.lower()
+    assert (
+        "create manifest" in output2.lower() or "generate manifest" in output2.lower()
+    )

--- a/tests/test_task_031_init_command.py
+++ b/tests/test_task_031_init_command.py
@@ -1,0 +1,262 @@
+"""Behavioral tests for Task-031: 'maid init' CLI command.
+
+Tests verify that the init command:
+1. Creates necessary directory structure (manifests/, tests/, .maid/docs/)
+2. Creates an example manifest file
+3. Copies maid_specs.md to .maid/docs/
+4. Generates proper MAID documentation content
+5. Handles CLAUDE.md creation/update with user confirmation
+"""
+
+import json
+from unittest.mock import patch
+
+from maid_runner.cli.init import (
+    copy_maid_specs,
+    create_directories,
+    create_example_manifest,
+    generate_claude_md_content,
+    handle_claude_md,
+    run_init,
+)
+
+
+class TestCreateDirectories:
+    """Test directory creation functionality."""
+
+    def test_creates_manifests_directory(self, tmp_path):
+        """Verify manifests/ directory is created."""
+        create_directories(str(tmp_path))
+        assert (tmp_path / "manifests").exists()
+        assert (tmp_path / "manifests").is_dir()
+
+    def test_creates_tests_directory(self, tmp_path):
+        """Verify tests/ directory is created."""
+        create_directories(str(tmp_path))
+        assert (tmp_path / "tests").exists()
+        assert (tmp_path / "tests").is_dir()
+
+    def test_creates_maid_docs_directory(self, tmp_path):
+        """Verify .maid/docs/ directory is created."""
+        create_directories(str(tmp_path))
+        assert (tmp_path / ".maid" / "docs").exists()
+        assert (tmp_path / ".maid" / "docs").is_dir()
+
+    def test_does_not_fail_if_directories_exist(self, tmp_path):
+        """Verify idempotency - no error if directories already exist."""
+        (tmp_path / "manifests").mkdir()
+        (tmp_path / "tests").mkdir()
+        (tmp_path / ".maid" / "docs").mkdir(parents=True)
+        create_directories(str(tmp_path))  # Should not raise
+        assert (tmp_path / "manifests").exists()
+        assert (tmp_path / "tests").exists()
+        assert (tmp_path / ".maid" / "docs").exists()
+
+
+class TestCreateExampleManifest:
+    """Test example manifest creation."""
+
+    def test_creates_example_manifest_file(self, tmp_path):
+        """Verify example manifest file is created."""
+        (tmp_path / "manifests").mkdir()
+        create_example_manifest(str(tmp_path))
+        example_file = tmp_path / "manifests" / "example.manifest.json"
+        assert example_file.exists()
+
+    def test_example_manifest_is_valid_json(self, tmp_path):
+        """Verify example manifest contains valid JSON."""
+        (tmp_path / "manifests").mkdir()
+        create_example_manifest(str(tmp_path))
+        example_file = tmp_path / "manifests" / "example.manifest.json"
+        with open(example_file) as f:
+            data = json.load(f)
+        assert isinstance(data, dict)
+
+    def test_example_manifest_has_required_fields(self, tmp_path):
+        """Verify example manifest includes all required MAID fields."""
+        (tmp_path / "manifests").mkdir()
+        create_example_manifest(str(tmp_path))
+        example_file = tmp_path / "manifests" / "example.manifest.json"
+        with open(example_file) as f:
+            data = json.load(f)
+
+        required_fields = [
+            "goal",
+            "taskType",
+            "creatableFiles",
+            "editableFiles",
+            "readonlyFiles",
+            "expectedArtifacts",
+            "validationCommand",
+        ]
+        for field in required_fields:
+            assert field in data, f"Missing required field: {field}"
+
+
+class TestCopyMaidSpecs:
+    """Test MAID specification document copying."""
+
+    def test_copies_maid_specs_to_target_directory(self, tmp_path):
+        """Verify maid_specs.md is copied to .maid/docs/."""
+        (tmp_path / ".maid" / "docs").mkdir(parents=True)
+        copy_maid_specs(str(tmp_path))
+        maid_specs = tmp_path / ".maid" / "docs" / "maid_specs.md"
+        assert maid_specs.exists()
+
+    def test_copied_file_is_not_empty(self, tmp_path):
+        """Verify copied maid_specs.md contains content."""
+        (tmp_path / ".maid" / "docs").mkdir(parents=True)
+        copy_maid_specs(str(tmp_path))
+        maid_specs = tmp_path / ".maid" / "docs" / "maid_specs.md"
+        content = maid_specs.read_text()
+        assert len(content) > 0
+        assert "MAID" in content
+
+    def test_handles_missing_source_gracefully(self, tmp_path):
+        """Verify graceful handling when source maid_specs.md not found."""
+        (tmp_path / ".maid" / "docs").mkdir(parents=True)
+
+        # The function should print a warning but not raise when source is missing
+        # This test just verifies it doesn't crash
+        copy_maid_specs(str(tmp_path))  # Should not raise
+
+
+class TestGenerateClaudeMdContent:
+    """Test CLAUDE.md content generation."""
+
+    def test_returns_string_content(self):
+        """Verify function returns a string."""
+        content = generate_claude_md_content()
+        assert isinstance(content, str)
+        assert len(content) > 0
+
+    def test_includes_maid_workflow_phases(self):
+        """Verify content includes MAID workflow phases."""
+        content = generate_claude_md_content()
+        assert "Phase 1" in content or "Goal Definition" in content
+        assert "Phase 2" in content or "Planning Loop" in content
+        assert "Phase 3" in content or "Implementation" in content
+
+    def test_includes_manifest_template(self):
+        """Verify content includes manifest template."""
+        content = generate_claude_md_content()
+        assert "goal" in content
+        assert "expectedArtifacts" in content
+        assert "validationCommand" in content
+
+    def test_includes_validation_commands(self):
+        """Verify content includes MAID CLI commands."""
+        content = generate_claude_md_content()
+        assert "maid validate" in content
+
+    def test_mentions_ai_agents(self):
+        """Verify content mentions MAID-compatible AI agents."""
+        content = generate_claude_md_content()
+        assert "AI" in content or "agent" in content.lower()
+
+    def test_references_local_maid_specs(self):
+        """Verify content references .maid/docs/maid_specs.md."""
+        content = generate_claude_md_content()
+        assert ".maid/docs/maid_specs.md" in content
+
+
+class TestHandleClaudeMd:
+    """Test CLAUDE.md file handling."""
+
+    def test_creates_claude_md_if_not_exists(self, tmp_path):
+        """Verify CLAUDE.md is created when it doesn't exist."""
+        handle_claude_md(str(tmp_path), force=False)
+        claude_md = tmp_path / "CLAUDE.md"
+        assert claude_md.exists()
+
+    def test_created_file_contains_maid_content(self, tmp_path):
+        """Verify created CLAUDE.md contains MAID documentation."""
+        handle_claude_md(str(tmp_path), force=False)
+        claude_md = tmp_path / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "MAID" in content
+        assert len(content) > 100
+
+    @patch("builtins.input", return_value="a")
+    def test_appends_to_existing_file_when_user_chooses_append(
+        self, mock_input, tmp_path
+    ):
+        """Verify content is appended when user chooses 'append'."""
+        claude_md = tmp_path / "CLAUDE.md"
+        existing_content = "# Existing Project Documentation\n\nSome content here."
+        claude_md.write_text(existing_content)
+
+        handle_claude_md(str(tmp_path), force=False)
+
+        content = claude_md.read_text()
+        assert existing_content in content
+        assert "MAID" in content
+
+    @patch("builtins.input", return_value="o")
+    def test_overwrites_when_user_chooses_overwrite(self, mock_input, tmp_path):
+        """Verify file is overwritten when user chooses 'overwrite'."""
+        claude_md = tmp_path / "CLAUDE.md"
+        existing_content = "# Existing Project Documentation"
+        claude_md.write_text(existing_content)
+
+        handle_claude_md(str(tmp_path), force=False)
+
+        content = claude_md.read_text()
+        assert existing_content not in content
+        assert "MAID" in content
+
+    @patch("builtins.input", return_value="s")
+    def test_skips_when_user_chooses_skip(self, mock_input, tmp_path):
+        """Verify file is unchanged when user chooses 'skip'."""
+        claude_md = tmp_path / "CLAUDE.md"
+        existing_content = "# Existing Project Documentation"
+        claude_md.write_text(existing_content)
+
+        handle_claude_md(str(tmp_path), force=False)
+
+        content = claude_md.read_text()
+        assert content == existing_content
+
+    def test_force_overwrites_without_prompt(self, tmp_path):
+        """Verify force flag overwrites without prompting."""
+        claude_md = tmp_path / "CLAUDE.md"
+        existing_content = "# Existing Project Documentation"
+        claude_md.write_text(existing_content)
+
+        # Should not prompt with force=True
+        handle_claude_md(str(tmp_path), force=True)
+
+        content = claude_md.read_text()
+        assert existing_content not in content
+        assert "MAID" in content
+
+
+class TestRunInit:
+    """Test main run_init function."""
+
+    @patch("builtins.input", return_value="s")
+    def test_creates_complete_structure(self, mock_input, tmp_path):
+        """Verify run_init creates all necessary files and directories."""
+        run_init(str(tmp_path), force=False)
+
+        # Check directories
+        assert (tmp_path / "manifests").exists()
+        assert (tmp_path / "tests").exists()
+        assert (tmp_path / ".maid" / "docs").exists()
+
+        # Check files
+        assert (tmp_path / "manifests" / "example.manifest.json").exists()
+        assert (tmp_path / ".maid" / "docs" / "maid_specs.md").exists()
+        assert (tmp_path / "CLAUDE.md").exists()
+
+    def test_with_force_flag(self, tmp_path):
+        """Verify force flag bypasses prompts."""
+        # Pre-create CLAUDE.md
+        (tmp_path / "CLAUDE.md").write_text("Old content")
+
+        run_init(str(tmp_path), force=True)
+
+        # Should overwrite without prompting
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert "Old content" not in content
+        assert "MAID" in content

--- a/tests/validators/test_abc_usage.py
+++ b/tests/validators/test_abc_usage.py
@@ -1,0 +1,193 @@
+"""Tests for abstract base class usage detection in behavioral validation.
+
+These tests verify that the validator correctly detects when abstract base classes
+are "used" in behavioral tests through patterns like:
+- Using as a base class
+- isinstance checks
+- issubclass checks
+- hasattr checks
+"""
+
+from pathlib import Path
+from maid_runner.validators.manifest_validator import validate_with_ast
+
+
+def test_detects_class_used_as_base_class(tmp_path: Path):
+    """Test that validator detects when a class is used as a base class."""
+    code = """
+from abc import ABC
+
+class BaseClass(ABC):
+    pass
+
+class ConcreteClass(BaseClass):
+    pass
+
+def test_something():
+    obj = ConcreteClass()
+    assert obj is not None
+"""
+    test_file = tmp_path / "test_base_class.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "BaseClass"},
+                {"type": "class", "name": "ConcreteClass"},
+            ]
+        }
+    }
+    # Should pass - BaseClass is used as a base class for ConcreteClass
+    validate_with_ast(manifest, str(test_file), validation_mode="behavioral")
+
+
+def test_detects_class_used_in_isinstance(tmp_path: Path):
+    """Test that validator detects when a class is used in isinstance check."""
+    code = """
+class MyClass:
+    pass
+
+class SubClass(MyClass):
+    pass
+
+def test_isinstance_check():
+    obj = SubClass()
+    assert isinstance(obj, MyClass)
+"""
+    test_file = tmp_path / "test_isinstance.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "MyClass"},
+                {"type": "class", "name": "SubClass"},
+            ]
+        }
+    }
+    # Should pass - MyClass is used in isinstance check
+    validate_with_ast(manifest, str(test_file), validation_mode="behavioral")
+
+
+def test_detects_class_used_in_issubclass(tmp_path: Path):
+    """Test that validator detects when a class is used in issubclass check."""
+    code = """
+class ParentClass:
+    pass
+
+class ChildClass(ParentClass):
+    pass
+
+def test_issubclass_check():
+    assert issubclass(ChildClass, ParentClass)
+"""
+    test_file = tmp_path / "test_issubclass.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "ParentClass"},
+                {"type": "class", "name": "ChildClass"},
+            ]
+        }
+    }
+    # Should pass - ParentClass is used in issubclass check
+    validate_with_ast(manifest, str(test_file), validation_mode="behavioral")
+
+
+def test_detects_class_used_in_hasattr(tmp_path: Path):
+    """Test that validator detects when a class is used in hasattr check."""
+    code = """
+class MyClass:
+    @staticmethod
+    def my_method():
+        pass
+
+def test_hasattr_check():
+    assert hasattr(MyClass, 'my_method')
+"""
+    test_file = tmp_path / "test_hasattr.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "MyClass"},
+            ]
+        }
+    }
+    # Should pass - MyClass is used in hasattr check
+    validate_with_ast(manifest, str(test_file), validation_mode="behavioral")
+
+
+def test_detects_class_assigned_to_variable(tmp_path: Path):
+    """Test that validator detects when a class is assigned to a variable and used."""
+    code = """
+class BaseClass:
+    pass
+
+class ConcreteClass(BaseClass):
+    pass
+
+def test_class_variable():
+    base_ref = BaseClass
+    obj = ConcreteClass()
+    assert issubclass(type(obj), base_ref)
+"""
+    test_file = tmp_path / "test_class_variable.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "BaseClass"},
+                {"type": "class", "name": "ConcreteClass"},
+            ]
+        }
+    }
+    # Should pass - BaseClass is assigned to variable and used
+    validate_with_ast(manifest, str(test_file), validation_mode="behavioral")
+
+
+def test_abstract_base_class_pattern(tmp_path: Path):
+    """Test the real-world ABC pattern from Task-005."""
+    code = """
+from abc import ABC, abstractmethod
+
+class BaseAgent(ABC):
+    @abstractmethod
+    def execute(self) -> dict:
+        pass
+
+class ConcreteAgent(BaseAgent):
+    def execute(self) -> dict:
+        return {"status": "success"}
+
+def test_base_agent_can_be_subclassed():
+    agent = ConcreteAgent()
+    assert isinstance(agent, BaseAgent)
+
+    base_agent_ref = BaseAgent
+    assert issubclass(type(agent), base_agent_ref)
+
+def test_execute_method():
+    agent = ConcreteAgent()
+    result = agent.execute()
+    assert isinstance(result, dict)
+    assert hasattr(BaseAgent, 'execute')
+"""
+    test_file = tmp_path / "test_abc_pattern.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "BaseAgent"},
+                {"type": "function", "name": "execute", "class": "BaseAgent"},
+            ]
+        }
+    }
+    # Should pass - BaseAgent is used in multiple ways typical of ABCs
+    validate_with_ast(manifest, str(test_file), validation_mode="behavioral")

--- a/tests/validators/test_ast_validator_structure.py
+++ b/tests/validators/test_ast_validator_structure.py
@@ -3,10 +3,19 @@ import pytest
 from pathlib import Path
 from maid_runner.validators.manifest_validator import validate_with_ast, AlignmentError
 
-# We'll use a more complex dummy file now
+# We'll use a more complex dummy file with DEFINED classes (not imported)
 DUMMY_TEST_CODE = """
 import pytest
-from my_app.models import User, Product
+
+class User:
+    def __init__(self, name, user_id):
+        self.name = name
+        self.user_id = user_id
+
+class Product:
+    def __init__(self, sku, price):
+        self.sku = sku
+        self.price = price
 
 def test_user_creation():
     # Using a standard variable name

--- a/tests/validators/test_ast_validator_structure.py
+++ b/tests/validators/test_ast_validator_structure.py
@@ -126,7 +126,13 @@ class Calculator:
                 {
                     "type": "class",
                     "name": "Calculator",
-                },  # Include the class in manifest
+                },
+                {
+                    "type": "function",
+                    "name": "add",
+                    "class": "Calculator",
+                    "parameters": [{"name": "a"}, {"name": "b"}],
+                },
             ]
         }
     }
@@ -212,7 +218,18 @@ class Dog(Animal):
             "contains": [
                 {"type": "class", "name": "CustomError", "bases": ["Exception"]},
                 {"type": "class", "name": "ValidationError", "bases": ["ValueError"]},
+                {
+                    "type": "function",
+                    "name": "__init__",
+                    "class": "ValidationError",
+                    "parameters": [{"name": "message"}],
+                },
                 {"type": "class", "name": "Dog", "bases": ["Animal"]},
+                {
+                    "type": "function",
+                    "name": "bark",
+                    "class": "Dog",
+                },
                 {"type": "class", "name": "Animal"},  # No base specified
             ]
         }
@@ -403,7 +420,10 @@ class Calculator:
             "contains": [
                 {"type": "function", "name": "module_func"},
                 {"type": "class", "name": "Calculator"},
-                # Methods (add, subtract, multiply, from_string) should NOT be in functions
+                {"type": "function", "name": "add", "class": "Calculator"},
+                {"type": "function", "name": "subtract", "class": "Calculator"},
+                {"type": "function", "name": "multiply", "class": "Calculator"},
+                {"type": "function", "name": "from_string", "class": "Calculator"},
             ]
         }
     }
@@ -437,9 +457,11 @@ class OuterClass:
             "contains": [
                 {"type": "function", "name": "top_level"},
                 {"type": "class", "name": "OuterClass"},
+                {"type": "function", "name": "outer_method", "class": "OuterClass"},
                 {"type": "class", "name": "InnerClass"},  # Nested classes ARE collected
+                {"type": "function", "name": "inner_method", "class": "InnerClass"},
                 {"type": "class", "name": "DeepClass"},  # Even deeply nested ones
-                # Methods inside classes are correctly NOT collected as module functions
+                {"type": "function", "name": "deep_method", "class": "DeepClass"},
             ]
         }
     }
@@ -487,8 +509,10 @@ def standalone_function():
         "expectedArtifacts": {
             "contains": [
                 {"type": "class", "name": "Service"},
+                {"type": "function", "name": "static_method", "class": "Service"},
+                {"type": "function", "name": "class_method", "class": "Service"},
+                {"type": "function", "name": "instance_method", "class": "Service"},
                 {"type": "function", "name": "standalone_function"},
-                # Decorated methods should NOT be module functions
             ]
         }
     }

--- a/tests/validators/test_edge_cases.py
+++ b/tests/validators/test_edge_cases.py
@@ -222,8 +222,8 @@ def module_function():
         "expectedArtifacts": {
             "contains": [
                 {"type": "class", "name": "MyClass"},
+                {"type": "function", "name": "value", "class": "MyClass"},
                 {"type": "function", "name": "module_function"},
-                # Property methods should not be module functions
             ]
         }
     }

--- a/tests/validators/test_edge_cases.py
+++ b/tests/validators/test_edge_cases.py
@@ -9,6 +9,7 @@ This module tests how the validator handles:
 - Properties
 - Empty manifests
 - Minimal and full field specifications
+- Explicit 'self' parameter declarations (invalid)
 """
 
 import pytest
@@ -321,3 +322,75 @@ def use_container():
     }
     # Should pass - all optional fields work correctly
     validate_with_ast(manifest, str(test_file))
+
+
+def test_self_parameter_rejected_in_manifest(tmp_path: Path):
+    """Test that manifests declaring 'self' as explicit parameter are rejected."""
+    code = """
+class TestClass:
+    def __init__(self, name: str):
+        self.name = name
+
+    def method(self, value: int):
+        return value * 2
+"""
+    test_file = tmp_path / "self_param.py"
+    test_file.write_text(code)
+
+    # Manifest incorrectly declares 'self' as parameter
+    manifest_with_self = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "TestClass"},
+                {
+                    "type": "function",
+                    "name": "__init__",
+                    "class": "TestClass",
+                    "args": [
+                        {"name": "self", "type": "TestClass"},  # Invalid
+                        {"name": "name", "type": "str"},
+                    ],
+                },
+                {
+                    "type": "function",
+                    "name": "method",
+                    "class": "TestClass",
+                    "args": [
+                        {"name": "self", "type": "TestClass"},  # Invalid
+                        {"name": "value", "type": "int"},
+                    ],
+                },
+            ]
+        }
+    }
+
+    # Should fail - 'self' should not be in manifest
+    with pytest.raises(
+        AlignmentError,
+        match="Parameter 'self' should not be explicitly declared",
+    ):
+        validate_with_ast(manifest_with_self, str(test_file))
+
+    # Correct manifest without 'self'
+    manifest_correct = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "TestClass"},
+                {
+                    "type": "function",
+                    "name": "__init__",
+                    "class": "TestClass",
+                    "args": [{"name": "name", "type": "str"}],
+                },
+                {
+                    "type": "function",
+                    "name": "method",
+                    "class": "TestClass",
+                    "args": [{"name": "value", "type": "int"}],
+                },
+            ]
+        }
+    }
+
+    # Should pass - 'self' is implicit
+    validate_with_ast(manifest_correct, str(test_file))

--- a/tests/validators/test_imports.py
+++ b/tests/validators/test_imports.py
@@ -148,3 +148,31 @@ def main():
     }
     # Should pass - only uppercase names are tracked as classes
     validate_with_ast(manifest, str(test_file))
+
+
+def test_enum_import_not_tracked_as_local_class(tmp_path: Path):
+    """Test that enum.Enum imports are not tracked as local classes."""
+    code = """
+from enum import Enum
+
+class Status(Enum):
+    ACTIVE = 1
+    INACTIVE = 2
+
+def get_status():
+    return Status.ACTIVE
+"""
+    test_file = tmp_path / "enum_test.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "Status"},
+                {"type": "function", "name": "get_status"},
+                # Enum should NOT be tracked as a local class
+            ]
+        }
+    }
+    # Should pass - enum.Enum is a stdlib import, not a local class
+    validate_with_ast(manifest, str(test_file))

--- a/tests/validators/test_manifest_merger.py
+++ b/tests/validators/test_manifest_merger.py
@@ -122,13 +122,15 @@ def test_merge_expected_artifacts():
         # First manifest with validate_schema function
         content1 = {
             "expectedArtifacts": {
-                "contains": [{"type": "function", "name": "validate_schema"}]
+                "file": "validator.py",
+                "contains": [{"type": "function", "name": "validate_schema"}],
             }
         }
 
         # Second manifest with AlignmentError class and validate_with_ast function
         content2 = {
             "expectedArtifacts": {
+                "file": "validator.py",
                 "contains": [
                     {"type": "class", "name": "AlignmentError", "bases": ["Exception"]},
                     {
@@ -139,7 +141,7 @@ def test_merge_expected_artifacts():
                             {"name": "test_file_path"},
                         ],
                     },
-                ]
+                ],
             }
         }
 
@@ -149,7 +151,9 @@ def test_merge_expected_artifacts():
             json.dump(content2, f)
 
         # Merge artifacts
-        merged = _merge_expected_artifacts([str(manifest1), str(manifest2)])
+        merged = _merge_expected_artifacts(
+            [str(manifest1), str(manifest2)], target_file="validator.py"
+        )
 
         # Should have all three artifacts
         assert len(merged) == 3
@@ -180,20 +184,22 @@ def test_merge_handles_duplicates():
         # Both manifests declare the same function but with different detail levels
         content1 = {
             "expectedArtifacts": {
-                "contains": [{"type": "function", "name": "process_data"}]
+                "file": "processor.py",
+                "contains": [{"type": "function", "name": "process_data"}],
             }
         }
 
         # Second manifest adds parameters
         content2 = {
             "expectedArtifacts": {
+                "file": "processor.py",
                 "contains": [
                     {
                         "type": "function",
                         "name": "process_data",
                         "parameters": [{"name": "data"}, {"name": "options"}],
                     }
-                ]
+                ],
             }
         }
 
@@ -203,7 +209,9 @@ def test_merge_handles_duplicates():
             json.dump(content2, f)
 
         # Merge artifacts
-        merged = _merge_expected_artifacts([str(manifest1), str(manifest2)])
+        merged = _merge_expected_artifacts(
+            [str(manifest1), str(manifest2)], target_file="processor.py"
+        )
 
         # Should have only one function (not duplicated)
         assert len(merged) == 1
@@ -298,7 +306,7 @@ def test_empty_manifest_chain():
     manifests = discover_related_manifests("non_existent_file.py")
     assert manifests == []
 
-    merged = _merge_expected_artifacts([])
+    merged = _merge_expected_artifacts([], target_file="non_existent_file.py")
     assert merged == []
 
 

--- a/tests/validators/test_task_027_validate_unexpected_methods.py
+++ b/tests/validators/test_task_027_validate_unexpected_methods.py
@@ -1,0 +1,166 @@
+# tests/validators/test_task_027_validate_unexpected_methods.py
+import pytest
+from pathlib import Path
+from maid_runner.validators.manifest_validator import validate_with_ast, AlignmentError
+
+
+def test_unexpected_public_method_fails(tmp_path: Path):
+    """Tests that unexpected public methods cause validation to fail."""
+    code = """
+class MyClass:
+    def expected_method(self):
+        pass
+
+    def unexpected_public_method(self):
+        # This method is NOT declared in manifest, should fail
+        pass
+
+    def _private_method(self):
+        # Private methods should be allowed
+        pass
+"""
+    test_file = tmp_path / "with_methods.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "MyClass"},
+                {"type": "function", "name": "expected_method", "class": "MyClass"},
+                # unexpected_public_method is NOT listed, should fail
+            ]
+        }
+    }
+    with pytest.raises(
+        AlignmentError,
+        match="Unexpected public method\\(s\\) in class 'MyClass': unexpected_public_method",
+    ):
+        validate_with_ast(manifest, str(test_file))
+
+
+def test_private_methods_allowed(tmp_path: Path):
+    """Tests that private methods (starting with _) are allowed without declaration."""
+    code = """
+class MyClass:
+    def public_method(self):
+        pass
+
+    def _private_helper(self):
+        # Should be allowed
+        pass
+
+    def __dunder_method__(self):
+        # Should be allowed
+        pass
+"""
+    test_file = tmp_path / "with_private.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "MyClass"},
+                {"type": "function", "name": "public_method", "class": "MyClass"},
+                # Private methods not listed but should pass
+            ]
+        }
+    }
+    # Should not raise an error - private methods are allowed
+    validate_with_ast(manifest, str(test_file))
+
+
+def test_declared_methods_pass(tmp_path: Path):
+    """Tests that validation passes when all public methods are declared."""
+    code = """
+class Calculator:
+    def add(self, a, b):
+        return a + b
+
+    def subtract(self, a, b):
+        return a - b
+
+    def _internal_helper(self):
+        pass
+"""
+    test_file = tmp_path / "calculator.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "Calculator"},
+                {
+                    "type": "function",
+                    "name": "add",
+                    "class": "Calculator",
+                    "parameters": [{"name": "a"}, {"name": "b"}],
+                },
+                {
+                    "type": "function",
+                    "name": "subtract",
+                    "class": "Calculator",
+                    "parameters": [{"name": "a"}, {"name": "b"}],
+                },
+            ]
+        }
+    }
+    # Should pass - all public methods are declared
+    validate_with_ast(manifest, str(test_file))
+
+
+def test_multiple_unexpected_methods_reported(tmp_path: Path):
+    """Tests that multiple unexpected methods are reported together."""
+    code = """
+class Service:
+    def expected_method(self):
+        pass
+
+    def extra_method1(self):
+        pass
+
+    def extra_method2(self):
+        pass
+"""
+    test_file = tmp_path / "service.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                {"type": "class", "name": "Service"},
+                {"type": "function", "name": "expected_method", "class": "Service"},
+            ]
+        }
+    }
+    # Should report all unexpected methods
+    with pytest.raises(AlignmentError) as exc_info:
+        validate_with_ast(manifest, str(test_file))
+
+    error_msg = str(exc_info.value)
+    # Check that it mentions unexpected methods
+    assert "extra_method1" in error_msg and "extra_method2" in error_msg
+
+
+def test_private_class_public_methods_allowed(tmp_path: Path):
+    """Tests that public methods in private classes don't need declaration."""
+    code = """
+class _PrivateClass:
+    def public_method(self):
+        # Public method in private class - should be allowed
+        pass
+
+    def another_public_method(self):
+        pass
+"""
+    test_file = tmp_path / "private_class.py"
+    test_file.write_text(code)
+
+    manifest = {
+        "expectedArtifacts": {
+            "contains": [
+                # Private class not declared, and its methods not declared either
+            ]
+        }
+    }
+    # Should pass - private classes and their methods don't need declaration
+    validate_with_ast(manifest, str(test_file))

--- a/tests/validators/test_task_028_file_tracking.py
+++ b/tests/validators/test_task_028_file_tracking.py
@@ -1,0 +1,369 @@
+# tests/validators/test_task_028_file_tracking.py
+from pathlib import Path
+from maid_runner.validators.file_tracker import (
+    FILE_STATUS_UNDECLARED,
+    FILE_STATUS_REGISTERED,
+    FILE_STATUS_TRACKED,
+    find_source_files,
+    collect_tracked_files,
+    classify_file_status,
+    analyze_file_tracking,
+)
+
+
+# ============================================================================
+# Test Constants and Status Classification
+# ============================================================================
+
+
+def test_file_status_constants_exist():
+    """Test that file status constants are defined."""
+    assert FILE_STATUS_UNDECLARED == "UNDECLARED"
+    assert FILE_STATUS_REGISTERED == "REGISTERED"
+    assert FILE_STATUS_TRACKED == "TRACKED"
+
+
+# ============================================================================
+# Test File Discovery
+# ============================================================================
+
+
+def test_find_source_files_discovers_python_files(tmp_path: Path):
+    """Test that find_source_files discovers all Python files."""
+    # Create test structure
+    (tmp_path / "module.py").write_text("# module")
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "file.py").write_text("# file")
+    (tmp_path / "another.py").write_text("# another")
+
+    files = find_source_files(str(tmp_path), exclude_patterns=[])
+
+    assert "module.py" in files
+    assert "subdir/file.py" in files
+    assert "another.py" in files
+
+
+def test_find_source_files_excludes_pycache(tmp_path: Path):
+    """Test that __pycache__ directories are excluded."""
+    (tmp_path / "module.py").write_text("# module")
+    (tmp_path / "__pycache__").mkdir()
+    (tmp_path / "__pycache__" / "module.cpython-312.pyc").write_text("bytecode")
+
+    files = find_source_files(str(tmp_path), exclude_patterns=["**/__pycache__/**"])
+
+    assert "module.py" in files
+    assert "__pycache__/module.cpython-312.pyc" not in files
+
+
+def test_find_source_files_excludes_venv(tmp_path: Path):
+    """Test that virtual environment directories are excluded."""
+    (tmp_path / "app.py").write_text("# app")
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "lib").mkdir(parents=True)
+    (tmp_path / ".venv" / "lib" / "python.py").write_text("# stdlib")
+
+    files = find_source_files(str(tmp_path), exclude_patterns=[".venv/**"])
+
+    assert "app.py" in files
+    assert ".venv/lib/python.py" not in files
+
+
+def test_find_source_files_with_custom_exclude_patterns(tmp_path: Path):
+    """Test that custom exclude patterns work."""
+    (tmp_path / "app.py").write_text("# app")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_app.py").write_text("# test")
+    (tmp_path / "experiments").mkdir()
+    (tmp_path / "experiments" / "exp.py").write_text("# experiment")
+
+    files = find_source_files(
+        str(tmp_path), exclude_patterns=["tests/**", "experiments/**"]
+    )
+
+    assert "app.py" in files
+    assert "tests/test_app.py" not in files
+    assert "experiments/exp.py" not in files
+
+
+# ============================================================================
+# Test Tracked Files Collection
+# ============================================================================
+
+
+def test_collect_tracked_files_from_creatableFiles():
+    """Test collecting files from creatableFiles."""
+    manifest_chain = [
+        {
+            "goal": "Create new module",
+            "creatableFiles": ["module.py"],
+            "expectedArtifacts": {
+                "file": "module.py",
+                "contains": [{"type": "function", "name": "main"}],
+            },
+            "validationCommand": ["pytest", "tests/test_module.py"],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    assert "module.py" in tracked
+    assert tracked["module.py"]["created"] is True
+    assert tracked["module.py"]["has_artifacts"] is True
+    assert tracked["module.py"]["has_tests"] is True
+
+
+def test_collect_tracked_files_from_editableFiles():
+    """Test collecting files from editableFiles."""
+    manifest_chain = [
+        {
+            "goal": "Edit existing module",
+            "editableFiles": ["module.py"],
+            "expectedArtifacts": {
+                "file": "module.py",
+                "contains": [{"type": "function", "name": "updated_func"}],
+            },
+            "validationCommand": ["pytest", "tests/test_module.py"],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    assert "module.py" in tracked
+    assert tracked["module.py"]["edited"] is True
+    assert tracked["module.py"]["has_artifacts"] is True
+
+
+def test_collect_tracked_files_from_readonlyFiles():
+    """Test collecting files from readonlyFiles."""
+    manifest_chain = [
+        {
+            "goal": "Use utility",
+            "creatableFiles": ["app.py"],
+            "readonlyFiles": ["utils.py"],
+            "expectedArtifacts": {
+                "file": "app.py",
+                "contains": [{"type": "function", "name": "main"}],
+            },
+            "validationCommand": ["pytest", "tests/test_app.py"],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    assert "utils.py" in tracked
+    assert tracked["utils.py"]["readonly"] is True
+    assert tracked["utils.py"]["created"] is False
+
+
+def test_collect_tracked_files_handles_multiple_manifests():
+    """Test that files appearing in multiple manifests are properly tracked."""
+    manifest_chain = [
+        {
+            "goal": "Create module",
+            "creatableFiles": ["module.py"],
+            "expectedArtifacts": {
+                "file": "module.py",
+                "contains": [{"type": "function", "name": "func1"}],
+            },
+            "validationCommand": ["pytest", "tests/test_module.py"],
+        },
+        {
+            "goal": "Update module",
+            "editableFiles": ["module.py"],
+            "expectedArtifacts": {
+                "file": "module.py",
+                "contains": [{"type": "function", "name": "func2"}],
+            },
+            "validationCommand": ["pytest", "tests/test_module.py"],
+        },
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    assert "module.py" in tracked
+    assert tracked["module.py"]["created"] is True
+    assert tracked["module.py"]["edited"] is True
+    assert len(tracked["module.py"]["manifests"]) == 2
+
+
+# ============================================================================
+# Test File Status Classification
+# ============================================================================
+
+
+def test_classify_file_status_undeclared():
+    """Test that files not in tracked_info are classified as UNDECLARED."""
+    status, issues = classify_file_status("untracked.py", tracked_info=None)
+
+    assert status == FILE_STATUS_UNDECLARED
+    assert "Not found in any manifest" in issues[0]
+
+
+def test_classify_file_status_registered_readonly_only():
+    """Test that files only in readonlyFiles are REGISTERED."""
+    tracked_info = {
+        "readonly": True,
+        "created": False,
+        "edited": False,
+        "has_artifacts": False,
+        "has_tests": False,
+        "manifests": ["task-001"],
+    }
+
+    status, issues = classify_file_status("utils.py", tracked_info)
+
+    assert status == FILE_STATUS_REGISTERED
+    assert any("Only in readonlyFiles" in issue for issue in issues)
+
+
+def test_classify_file_status_registered_no_artifacts():
+    """Test that files without artifacts are REGISTERED."""
+    tracked_info = {
+        "readonly": False,
+        "created": False,
+        "edited": True,
+        "has_artifacts": False,
+        "has_tests": False,
+        "manifests": ["task-005"],
+    }
+
+    status, issues = classify_file_status("module.py", tracked_info)
+
+    assert status == FILE_STATUS_REGISTERED
+    assert any("no expectedArtifacts" in issue for issue in issues)
+
+
+def test_classify_file_status_registered_no_tests():
+    """Test that files without tests are REGISTERED."""
+    tracked_info = {
+        "readonly": False,
+        "created": True,
+        "edited": False,
+        "has_artifacts": True,
+        "has_tests": False,
+        "manifests": ["task-010"],
+    }
+
+    status, issues = classify_file_status("service.py", tracked_info)
+
+    assert status == FILE_STATUS_REGISTERED
+    assert any("no behavioral tests" in issue for issue in issues)
+
+
+def test_classify_file_status_tracked():
+    """Test that fully compliant files are TRACKED."""
+    tracked_info = {
+        "readonly": False,
+        "created": True,
+        "edited": False,
+        "has_artifacts": True,
+        "has_tests": True,
+        "manifests": ["task-015"],
+    }
+
+    status, issues = classify_file_status("complete.py", tracked_info)
+
+    assert status == FILE_STATUS_TRACKED
+    assert len(issues) == 0
+
+
+def test_classify_file_status_tracked_with_edits():
+    """Test that files created then edited are still TRACKED if compliant."""
+    tracked_info = {
+        "readonly": False,
+        "created": True,
+        "edited": True,
+        "has_artifacts": True,
+        "has_tests": True,
+        "manifests": ["task-001", "task-010"],
+    }
+
+    status, issues = classify_file_status("evolving.py", tracked_info)
+
+    assert status == FILE_STATUS_TRACKED
+    assert len(issues) == 0
+
+
+# ============================================================================
+# Test Full Analysis
+# ============================================================================
+
+
+def test_analyze_file_tracking_integration(tmp_path: Path):
+    """Test full file tracking analysis with mixed file statuses."""
+    # Create test files
+    (tmp_path / "tracked.py").write_text("# fully tracked")
+    (tmp_path / "registered.py").write_text("# registered only")
+    (tmp_path / "undeclared.py").write_text("# not in manifests")
+
+    manifest_chain = [
+        {
+            "goal": "Create tracked module",
+            "creatableFiles": ["tracked.py"],
+            "expectedArtifacts": {
+                "file": "tracked.py",
+                "contains": [{"type": "function", "name": "main"}],
+            },
+            "validationCommand": ["pytest", "tests/test_tracked.py"],
+        },
+        {
+            "goal": "Use registered module",
+            "creatableFiles": ["app.py"],
+            "readonlyFiles": ["registered.py"],
+            "expectedArtifacts": {"file": "app.py", "contains": []},
+            "validationCommand": ["echo", "test"],
+        },
+    ]
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    # Check that all categories are present
+    assert "undeclared" in analysis
+    assert "registered" in analysis
+    assert "tracked" in analysis
+
+    # Check undeclared files
+    undeclared_files = [f["file"] for f in analysis["undeclared"]]
+    assert "undeclared.py" in undeclared_files
+
+    # Check registered files
+    registered_files = [f["file"] for f in analysis["registered"]]
+    assert "registered.py" in registered_files
+
+    # Check tracked files
+    assert "tracked.py" in analysis["tracked"]
+
+
+def test_analyze_file_tracking_empty_codebase(tmp_path: Path):
+    """Test analysis with empty codebase."""
+    manifest_chain = []
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    assert len(analysis["undeclared"]) == 0
+    assert len(analysis["registered"]) == 0
+    assert len(analysis["tracked"]) == 0
+
+
+def test_analyze_file_tracking_all_tracked(tmp_path: Path):
+    """Test analysis when all files are fully tracked."""
+    (tmp_path / "module1.py").write_text("# module1")
+    (tmp_path / "module2.py").write_text("# module2")
+
+    manifest_chain = [
+        {
+            "goal": "Create modules",
+            "creatableFiles": ["module1.py", "module2.py"],
+            "expectedArtifacts": {
+                "file": "module1.py",
+                "contains": [{"type": "function", "name": "func"}],
+            },
+            "validationCommand": ["pytest", "tests/"],
+        }
+    ]
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    assert len(analysis["undeclared"]) == 0
+    # module2.py might be REGISTERED (no artifacts for it specifically)
+    assert "module1.py" in analysis["tracked"]


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Implement new `maid test` command for executing validation commands from manifests with timeout handling, fail-fast mode, and comprehensive test suite

- Add `--manifest-dir` option to `maid validate` for batch validation of multiple manifests with superseded filtering

- Fix artifact collection in manifest validator: distinguish imported classes from defined classes, filter artifacts by target file, and improve behavioral validation detection

- Enhance behavioral validation to detect abstract base class usage patterns (isinstance, issubclass, hasattr checks) and classmethod/staticmethod calls on class names

- Fix validator to filter both `self` and `cls` parameters from method validation and reject explicit `self` parameter declarations in manifests

- Refactor `get_superseded_manifests()` utility function to centralized location in `maid_runner/utils.py` for reuse across scripts

- Add comprehensive test coverage for all new features and bug fixes with 9 new test suites (2,000+ lines)

- Improve CLI hooks and documentation to use `maid` CLI commands instead of direct Python scripts

- Update test runner hook for better reliability with list-based subprocess calls and improved error output handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["maid test command"] -->|executes| B["validation commands"]
  B -->|with timeout| C["error handling"]
  D["maid validate --manifest-dir"] -->|processes| E["multiple manifests"]
  E -->|filters| F["superseded manifests"]
  G["manifest validator"] -->|distinguishes| H["imports vs definitions"]
  G -->|detects| I["ABC usage patterns"]
  G -->|filters| J["self/cls parameters"]
  K["get_superseded_manifests"] -->|centralized| L["maid_runner/utils.py"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_021_maid_test_command.py</strong><dd><code>Comprehensive behavioral tests for maid test command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_021_maid_test_command.py

<ul><li>New comprehensive test suite for the <code>maid test</code> command with 563 lines <br>of behavioral tests<br> <li> Tests cover core functionality: running validation commands, handling <br>superseded manifests, fail-fast mode, and single manifest execution<br> <li> Tests verify the <code>run_test()</code>, <code>execute_validation_commands()</code>, and <code>main()</code> <br>functions are properly importable and functional<br> <li> Tests validate command execution, timeout handling, and summary <br>reporting</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-0ada3234d338558251a0b47a964b2abbafa481b9d7661101782db063e2e5d319">+563/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_024_import_vs_definition.py</strong><dd><code>Tests for import vs definition distinction in validator</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_024_import_vs_definition.py

<ul><li>New test suite with 347 lines verifying that imports are not treated <br>as defined artifacts<br> <li> Tests cover various import patterns: direct imports, local module <br>imports, relative imports, star imports, and aliased imports<br> <li> Tests verify that only class definitions (not imports) appear in <br><code>found_classes</code><br> <li> Tests include regression tests for nested classes and inheritance <br>patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-c7e0b81e009a9c78f7e7efce7a3658a7b9d7bb769732cb58de330d685e98211b">+347/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_022_validate_manifest_dir.py</strong><dd><code>Tests for manifest directory validation feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_022_validate_manifest_dir.py

<ul><li>New test suite with 309 lines for the <code>--manifest-dir</code> validation <br>feature<br> <li> Tests verify directory validation, superseded manifest filtering, and <br>backward compatibility with single manifest mode<br> <li> Tests validate CLI behavior, function signatures, and error handling <br>for mutual exclusivity<br> <li> Tests confirm summary reporting and proper exit codes</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-49fcec221caedd887c8ca64524fdd3dec8f45b45bb6f5eb05a88a0236b069f0c">+309/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_behavioral_validation_without_impl.py</strong><dd><code>Tests for behavioral validation without implementation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/cli/test_behavioral_validation_without_impl.py

<ul><li>New test suite with 256 lines for behavioral validation without <br>implementation files<br> <li> Tests verify that behavioral validation passes when implementation <br>doesn't exist but tests do<br> <li> Tests confirm implementation validation fails appropriately when files <br>are missing<br> <li> Tests validate helpful error messages and hints for users about <br>validation modes</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-e22fb1501eb524a968cb2e61851c0bcbb56a5d31fe78c8cdf532de0cc9b4410e">+256/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_023_fix_manifest_chain_artifact_filtering.py</strong><dd><code>Tests for manifest chain artifact filtering fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_023_fix_manifest_chain_artifact_filtering.py

<ul><li>New test suite with 215 lines for manifest chain artifact filtering by <br>target file<br> <li> Tests verify that <code>_merge_expected_artifacts()</code> only includes artifacts <br>matching the target file<br> <li> Tests cover edge cases: empty manifests, missing expectedArtifacts, <br>and artifact overrides<br> <li> Tests validate integration between <code>_get_expected_artifacts()</code> and <br><code>_merge_expected_artifacts()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-923048d7b8555b75736014b26d9e2521b6f9317450d34cf67a822dcc8e5025f1">+215/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_025_fix_cls_parameter.py</strong><dd><code>Tests for cls parameter filtering in validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_025_fix_cls_parameter.py

<ul><li>New test suite with 245 lines for <code>cls</code> parameter filtering in <br>classmethod validation<br> <li> Tests verify that classmethods validate correctly without <code>cls</code> in <br>manifest parameters<br> <li> Tests cover regular methods, classmethods, staticmethods, and mixed <br>method types<br> <li> Tests validate backward compatibility with existing <code>self</code> parameter <br>filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-662dbc81e78e7015c5cbfcd8c7f7ec3762262a0c07ec203bb0624081cfe178ed">+245/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_026_detect_classmethod_calls.py</strong><dd><code>Tests for classmethod call detection in behavioral mode</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_task_026_detect_classmethod_calls.py

<ul><li>New test suite with 255 lines for detecting classmethod calls on class <br>names<br> <li> Tests verify that direct classmethod and staticmethod calls are <br>detected in behavioral validation<br> <li> Tests cover multiple classmethod calls and verify instance method <br>detection still works<br> <li> Tests validate real-world usage patterns in test files</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-b5ddbf9de847a586847d05343ca698a02360b4e1daa7bd6ca556e6334feb1eff">+255/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_abc_usage.py</strong><dd><code>Tests for abstract base class usage detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/validators/test_abc_usage.py

<ul><li>New test suite with 193 lines for abstract base class usage detection<br> <li> Tests verify detection of classes used as base classes, in <br><code>isinstance()</code>, <code>issubclass()</code>, and <code>hasattr()</code> checks<br> <li> Tests cover class assignment to variables and real-world ABC patterns<br> <li> Tests validate behavioral validation correctly identifies class usage <br>patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-f161af8a3a115b0839366a9bf7e249c0de19f5feaa2718ae4c20f17a23321a24">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_imports.py</strong><dd><code>Fix import vs definition tracking in validator tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/validators/test_imports.py

<ul><li>Updated test docstrings to clarify that imports should NOT be tracked <br>as defined classes<br> <li> Commented out imported class assertions in three test cases <br>(<code>test_import_from_local_modules</code>, <code>test_relative_imports</code>, <br><code>test_mixed_case_imports</code>)<br> <li> Added clarifying comments distinguishing between IMPORTED vs DEFINED <br>artifacts<br> <li> Added new test <code>test_enum_import_not_tracked_as_local_class</code> to verify <br>enum.Enum imports are excluded</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-b4a3c8918fa9f99eb01cd0f1c68abd872a85da3aada9398d8e387f12b4354e0a">+52/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_020_refactor_superseded_utils.py</strong><dd><code>Add tests for refactored get_superseded_manifests utility</code></dd></summary>
<hr>

tests/test_task_020_refactor_superseded_utils.py

<ul><li>New test file validating <code>get_superseded_manifests()</code> function moved to <br><code>maid_runner.utils</code><br> <li> Tests verify function is importable, returns a set, correctly <br>identifies superseded manifests<br> <li> Tests cover edge cases: empty directories, missing supersedes field<br> <li> Validates that <code>run_manifest_validation_commands.py</code> uses proper utils <br>import instead of importlib hack</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-060ae15cdb38bb426dd6afff4f5e1a3df835b610b9ae13a2b8772c19166739e4">+116/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_manifest_merger.py</strong><dd><code>Update manifest merger tests with target file filtering</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/validators/test_manifest_merger.py

<ul><li>Added <code>"file": "validator.py"</code> and <code>"file": "processor.py"</code> fields to <br><code>expectedArtifacts</code> in test manifests<br> <li> Updated <code>_merge_expected_artifacts()</code> calls to include <code>target_file</code> <br>parameter<br> <li> Ensures artifact merging filters by target file correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-2c0ed29a86df551f66a79411c35c46c215b82f6a0e1b279123e76d21090b0be5">+15/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_edge_cases.py</strong><dd><code>Add test for rejecting explicit self parameter declarations</code></dd></summary>
<hr>

tests/validators/test_edge_cases.py

<ul><li>Added documentation note about explicit <code>self</code> parameter declarations <br>being invalid<br> <li> Added new test <code>test_self_parameter_rejected_in_manifest</code> verifying that <br>manifests declaring <code>self</code> as explicit parameter are rejected<br> <li> Test includes both invalid manifest (with <code>self</code>) and correct manifest <br>(without <code>self</code>)<br> <li> Validates error message matches expected pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-6c2567359d72099bef12005bb99fbe0fb679456504a76c455a51303d76769a88">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ast_validator_structure.py</strong><dd><code>Update test code to use defined classes instead of imports</code></dd></summary>
<hr>

tests/validators/test_ast_validator_structure.py

<ul><li>Updated <code>DUMMY_TEST_CODE</code> to define <code>User</code> and <code>Product</code> classes directly <br>instead of importing them<br> <li> Added class definitions with <code>__init__</code> methods to create actual defined <br>classes in test code<br> <li> Ensures test validates defined classes rather than imported ones</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-6eed43d5bc510393eafc79c0e62d62daecd08f972047d165474e91db87cc2154">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>validate.py</strong><dd><code>Add manifest directory validation and improve error handling</code></dd></summary>
<hr>

maid_runner/cli/validate.py

<ul><li>Added <code>--manifest-dir</code> option to validate all manifests in a directory <br>at once<br> <li> Implemented <code>_run_directory_validation()</code> helper function to process <br>multiple manifests with superseded filtering<br> <li> Enhanced <code>run_validation()</code> to support both single manifest and <br>directory modes with mutual exclusivity checks<br> <li> Added path normalization logic to handle redundant project directory <br>prefixes in file paths<br> <li> Improved error handling with helpful hints for behavioral vs <br>implementation validation modes<br> <li> Added validation for <code>self</code> parameter in method declarations with clear <br>error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-0202b2e12cfbbab63f8638d7aab6f668b384f2555eb30f87e9bed470fdd19e31">+265/-30</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Implement maid test command for validation execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

maid_runner/cli/test.py

<ul><li>New module implementing the <code>maid test</code> command for running validation <br>commands from manifests<br> <li> Implements <code>execute_validation_commands()</code> to run individual validation <br>commands with timeout and error handling<br> <li> Implements <code>run_test()</code> to orchestrate testing across multiple manifests <br>with superseded filtering<br> <li> Implements <code>main()</code> as CLI entry point with support for <code>--manifest</code>, <br><code>--manifest-dir</code>, <code>--fail-fast</code>, <code>--verbose</code>, <code>--quiet</code>, and <code>--timeout</code> options<br> <li> Includes PYTHONPATH setup and auto-prefixing of pytest commands with <br><code>uv run</code> for uv projects</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-a5c4dda58c8bcf1a359311c0d6893acfa16f340662056fb10ae720378e4087a7">+347/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-runner.py</strong><dd><code>Improve test runner hook reliability and output handling</code>&nbsp; </dd></summary>
<hr>

.claude/hooks/test-runner.py

<ul><li>Refactored to use list-based subprocess calls instead of shell strings <br>for better reliability<br> <li> Improved error output handling with truncation to last 10 lines to <br>reduce clutter<br> <li> Added support for both <code>validationCommand</code> and <code>validationCommands</code> <br>formats<br> <li> Changed comprehensive test suite to use <code>-q</code> flag for quieter output<br> <li> Removed unnecessary environment variable copying</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-b6054fc3371fecaf3b6f1718fe1878bec3f09753824175bc0a0eadf05fd4bd13">+35/-32</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast-validator.py</strong><dd><code>Refactor AST validator hook to use CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/hooks/ast-validator.py

<ul><li>Refactored to use <code>maid validate</code> CLI instead of direct AST validator <br>imports<br> <li> Simplified validation logic by delegating to CLI with <br><code>--use-manifest-chain</code> and <code>--quiet</code> flags<br> <li> Improved error handling and output formatting<br> <li> Removed direct Python imports of validator module</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-86a47322321d98a992894c56f8418ff08c5ee44b9338e40c3ef02f2b6359b28d">+41/-48</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validate_all_manifests.py</strong><dd><code>Refactor to use centralized utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/validate_all_manifests.py

<ul><li>Refactored <code>get_superseded_manifests()</code> to import from <code>maid_runner.utils</code> <br>instead of using dynamic module loading<br> <li> Simplified implementation by delegating to centralized utility <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-733777dc75e38bed7783ee9f9286239cac72c5444d01323c3db7cc2a861ff74b">+3/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add test subcommand and directory validation support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

maid_runner/cli/main.py

<ul><li>Modified <code>validate</code> subcommand: made <code>manifest_path</code> optional with <br><code>nargs="?"</code> to support directory validation<br> <li> Added <code>--manifest-dir</code> argument for validating all manifests in a <br>directory<br> <li> Updated help text for <code>--use-manifest-chain</code> to indicate automatic <br>enablement for directory validation<br> <li> Added new <code>test</code> subcommand with arguments: <code>--manifest</code>, <code>--manifest-dir</code>, <br><code>--fail-fast</code>, <code>--verbose</code>, <code>--quiet</code>, <code>--timeout</code><br> <li> Added validation logic to enforce mutual exclusivity between <br><code>manifest_path</code> and <code>--manifest-dir</code><br> <li> Added logic to auto-enable manifest chain for directory validation<br> <li> Added handler for <code>test</code> command that calls <code>run_test()</code> from <br><code>maid_runner.cli.test</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-669b8adf5885ecc5f8d309259e49a9c5a2f7d78a747780f573e6d8d87337732f">+83/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Add get_superseded_manifests utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

maid_runner/utils.py

<ul><li>Added imports: <code>json</code> and <code>Path</code> from pathlib<br> <li> Added new function <code>get_superseded_manifests()</code> that finds all manifests <br>superseded by other manifests<br> <li> Function handles relative and absolute paths, resolves paths correctly <br>relative to manifests directory<br> <li> Includes error handling for invalid JSON and missing files</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-eb8e8cc33592f24de3df5053f94b709e2985d768323096f56c2f6f69424f2cf7">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_manifest_to_implementation_alignment.py</strong><dd><code>Refactor superseded manifest detection for all manifest types</code></dd></summary>
<hr>

tests/test_manifest_to_implementation_alignment.py

<ul><li>Updated <code>get_superseded_manifests()</code> function to check ALL manifests for <br>supersedes declarations, not just snapshots<br> <li> Changed glob pattern from <code>task-*-snapshot-*.manifest.json</code> to <br><code>task-*.manifest.json</code><br> <li> Updated variable names and comments to reflect checking all manifests <br>instead of only snapshots<br> <li> Updated docstring and comments in <code>find_manifest_files()</code> to clarify <br>superseding applies to all manifests</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-1af2babd4761921bca18f5bbb5f7a7fbb485be55d5658f0d7e627791fa6aa977">+11/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest_validator.py</strong><dd><code>Fix artifact collection and improve behavioral validation detection</code></dd></summary>
<hr>

maid_runner/validators/manifest_validator.py

<ul><li>Fixed <code>visit_ImportFrom()</code> to not treat imported classes as defined <br>artifacts<br> <li> Enhanced <code>visit_ClassDef()</code> to track base classes as used in behavioral <br>mode<br> <li> Added <code>_track_class_name_assignments()</code> to detect class name assignments <br>to variables<br> <li> Added <code>_track_method_call_with_inheritance()</code> to propagate method calls <br>to base classes<br> <li> Improved <code>visit_Call()</code> to detect classmethod/staticmethod calls on <br>class names and handle <code>isinstance()</code>, <code>issubclass()</code>, and <code>hasattr()</code> <br>checks<br> <li> Fixed <code>_merge_expected_artifacts()</code> to filter artifacts by target file<br> <li> Added validation to reject manifests with explicit <code>self</code> parameter <br>declarations<br> <li> Updated <code>_validate_method_parameters()</code> to filter both <code>self</code> and <code>cls</code> <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-f78b974be91360b4b55f71dc8cfd6be713ab92320ba8c52609338a2bb5c73e13">+128/-32</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>run_manifest_validation_commands.py</strong><dd><code>Add utility import for superseded manifest detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/run_manifest_validation_commands.py

- Added import of `get_superseded_manifests` from `maid_runner.utils`


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-bee4b140695ee9b2e045d41c407feddbb52306e9dee28e337980314024ef7171">+2/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update documentation to use maid CLI instead of scripts</code>&nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Updated validation command from <code>validate_manifest.py</code> script to <code>maid </code><br><code>validate</code> CLI command<br> <li> Updated references to validation tools from direct Python scripts to <br><code>maid</code> CLI commands<br> <li> Added new "MAID CLI Commands" section documenting <code>maid validate</code>, <code>maid </code><br><code>snapshot</code>, and help commands<br> <li> Updated documentation to emphasize using CLI instead of direct Python <br>scripts</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+22/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update hook documentation to reference maid CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/hooks/README.md

<ul><li>Updated AST Validator Hook description to reference MAID CLI instead <br>of direct AST validation<br> <li> Changed implementation details to show <code>uv run maid validate</code> command <br>usage<br> <li> Updated to indicate validation includes both behavioral tests and <br>implementation alignment<br> <li> Clarified that hook blocks on validation failure</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-30020a42be08da2eeee00e44ce5b14d3cfb064ecaa3a0eeb8d02ed37737a3e56">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>task-021-maid-test-command.manifest.json</strong><dd><code>Add manifest for maid test command implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-021-maid-test-command.manifest.json

<ul><li>New manifest for implementing <code>maid test</code> CLI command<br> <li> Defines creatable file <code>maid_runner/cli/test.py</code> with three functions: <br><code>execute_validation_commands()</code>, <code>run_test()</code>, <code>main()</code><br> <li> Specifies function signatures with parameters and return types<br> <li> Includes validation command using pytest</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-2a104281d3805cd33bbe666513d86dc20d940fdff707fef90bd99009e13b33c1">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-022-add-manifest-dir-to-validate.manifest.json</strong><dd><code>Add manifest for directory validation feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-022-add-manifest-dir-to-validate.manifest.json

<ul><li>New manifest for adding <code>--manifest-dir</code> option to <code>maid validate</code> command<br> <li> Supersedes <code>task-004-behavioral-test-integration.manifest.json</code><br> <li> Defines editable file <code>maid_runner/cli/validate.py</code> with updated <br><code>run_validation()</code> function signature<br> <li> Specifies new <code>manifest_dir</code> parameter as Optional[str]</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-eb3368467bf01fb100b3930f77268e3118b10391e342295d6c7591578b0a0a29">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-023-fix-manifest-chain-artifact-filtering.manifest.json</strong><dd><code>Add manifest for artifact filtering by target file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-023-fix-manifest-chain-artifact-filtering.manifest.json

<ul><li>New manifest for fixing manifest chain artifact merging to filter by <br>target file<br> <li> Defines editable file <code>maid_runner/validators/manifest_validator.py</code><br> <li> Updates <code>_merge_expected_artifacts()</code> to accept <code>target_file</code> parameter<br> <li> Updates <code>_get_expected_artifacts()</code> to accept <code>use_manifest_chain</code> <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-477e45ce5a69d53f05b7027b1009cf9b6962dcd7daa941ffa59d3ab5b74ee741">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-016-detect-abc-usage-patterns.manifest.json</strong><dd><code>Add manifest for ABC usage pattern detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-016-detect-abc-usage-patterns.manifest.json

<ul><li>New manifest for enhancing behavioral validator to detect abstract <br>base class usage patterns<br> <li> Defines editable file <code>maid_runner/validators/manifest_validator.py</code><br> <li> Specifies <code>_ArtifactCollector</code> class with <code>visit_Call()</code> and <br><code>visit_ClassDef()</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-4bbae6573988514f831d25881a7412cf3497dccf26407ee2986358a3ef1497b7">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-025-fix-cls-parameter-filtering.manifest.json</strong><dd><code>Add manifest for cls parameter filtering fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-025-fix-cls-parameter-filtering.manifest.json

<ul><li>New manifest for fixing validator to filter both <code>self</code> and <code>cls</code> <br>parameters from method validation<br> <li> Defines editable file <code>maid_runner/validators/manifest_validator.py</code><br> <li> Specifies <code>_validate_method_parameters()</code> function with four parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-acddbd3d745c62946b648ff691abf66248f39806b9ad4167ab478410806f90df">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-020-refactor-superseded-utils.manifest.json</strong><dd><code>Add manifest for superseded utils refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-020-refactor-superseded-utils.manifest.json

<ul><li>New manifest for refactoring <code>get_superseded_manifests()</code> from scripts <br>to <code>maid_runner/utils.py</code><br> <li> Defines editable files: <code>maid_runner/utils.py</code> and <br><code>scripts/run_manifest_validation_commands.py</code><br> <li> Specifies <code>get_superseded_manifests()</code> function with <code>manifests_dir</code> <br>parameter returning set</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-f3167d1d077b79a983299acbc492207e5ca03f053010728d8c276845817b8752">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-015-fix-enum-import-detection.manifest.json</strong><dd><code>Add manifest for enum import detection fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-015-fix-enum-import-detection.manifest.json

<ul><li>New manifest for fixing validator to exclude enum imports from local <br>classes<br> <li> Defines editable file <code>maid_runner/validators/manifest_validator.py</code><br> <li> Specifies <code>_ArtifactCollector</code> class and <code>_is_local_import()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-150cf25969c44843d34fe583306a926e1b985e907db13cd950ec22b345cde97a">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-024-fix-import-vs-definition-tracking.manifest.json</strong><dd><code>Add manifest for import vs definition tracking fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-024-fix-import-vs-definition-tracking.manifest.json

<ul><li>New manifest for fixing validator to distinguish imported classes from <br>defined classes<br> <li> Defines editable file <code>maid_runner/validators/manifest_validator.py</code><br> <li> Specifies <code>_ArtifactCollector</code> class with description clarifying imports <br>vs definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-a143a63749bb0083d2716f38a650f09ba8d0308e4a72c3901be6e1c761efee55">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-026-detect-classmethod-calls-on-class.manifest.json</strong><dd><code>Add manifest for classmethod call detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-026-detect-classmethod-calls-on-class.manifest.json

<ul><li>New manifest for fixing validator to detect classmethod calls on class <br>names<br> <li> Defines editable file <code>maid_runner/validators/manifest_validator.py</code><br> <li> Specifies <code>visit_Call()</code> method in <code>_ArtifactCollector</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-8dc9382f1dbcaa1c80c14d06025016f52cb8611cc7ad86ddb01b791b7d04c43b">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-017-fix-behavioral-validation-file-check.manifest.json</strong><dd><code>Add manifest for behavioral validation file check fix</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-017-fix-behavioral-validation-file-check.manifest.json

<ul><li>New manifest for fixing behavioral validation to not require <br>implementation file existence<br> <li> Defines editable file <code>maid_runner/cli/validate.py</code><br> <li> Specifies empty <code>expectedArtifacts.contains</code> array (no new artifacts <br>required)</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-7dc94044cf332dd8f494ec6a76a534f62316f126f93a238547cf3be821a0a144">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-009-snapshot-manifest_validator.manifest.json</strong><dd><code>Update snapshot manifest with target_file parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-009-snapshot-manifest_validator.manifest.json

<ul><li>Updated <code>_merge_expected_artifacts()</code> function parameters to include new <br><code>target_file</code> parameter<br> <li> Added parameter definition with name <code>target_file</code> to function signature</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-f3741c5eeffeb5f5ddba5a368f9ba2cb6c8e409222ea43db7a2bd812fccd01b5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>task-004-behavioral-test-integration.manifest.json</strong></td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-ea02f54eb0b1a53c0fcf350c614770c44f8dac216f400a77933b5396b754ea4a">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task-013-pypi-packaging.manifest.json</strong></td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/24/files#diff-831cb73247fb3b5d199527ddcac33453192e2f6b0ca797bca5dbcaf4e481ab2f">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

