### PR TITLE
Update slash commands to use proper subagent invocation format

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -5,7 +5,7 @@ argument-hint: [optional: manifest-path or scope]
 
 Audit compliance: $ARGUMENTS
 
-Invokes maid-auditor agent to:
+Use the maid-auditor subagent to:
 
 1. **CRITICAL - Validate ALL (no arguments)**:
    ```

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -5,7 +5,7 @@ argument-hint: [optional: specific error context]
 
 Fix errors: $ARGUMENTS
 
-Invokes maid-fixer agent to:
+Use the maid-fixer subagent to:
 
 1. Collect errors: `maid validate` and `maid test`
 2. Fix one issue at a time

--- a/.claude/commands/generate-manifest.md
+++ b/.claude/commands/generate-manifest.md
@@ -5,7 +5,7 @@ argument-hint: [goal description]
 
 Create manifest for: $ARGUMENTS
 
-Invokes maid-manifest-architect agent to:
+Use the maid-manifest-architect subagent to:
 
 1. Find next task number
 2. Create `manifests/task-XXX-description.manifest.json`

--- a/.claude/commands/generate-tests.md
+++ b/.claude/commands/generate-tests.md
@@ -5,7 +5,7 @@ argument-hint: [manifest-path]
 
 Generate tests for manifest: $1
 
-Invokes maid-test-designer agent to:
+Use the maid-test-designer subagent to:
 
 1. Read manifest expectedArtifacts
 2. Create `tests/test_task_XXX_*.py`

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -5,7 +5,7 @@ argument-hint: [manifest-path]
 
 Implement: $1
 
-Invokes maid-developer agent to:
+Use the maid-developer subagent to:
 
 1. Confirm Red phase: tests fail
 2. Implement code to make tests pass

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -5,7 +5,7 @@ argument-hint: [goal description]
 
 Create complete plan for: $ARGUMENTS
 
-Invokes maid-manifest-architect + maid-test-designer agents to:
+Use the maid-manifest-architect and maid-test-designer subagents to:
 
 1. Phase 1: Create manifest
 2. Phase 2: Create behavioral tests that USE artifacts

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -5,7 +5,7 @@ argument-hint: [file-path or task-number]
 
 Refactor: $1
 
-Invokes maid-refactorer agent to:
+Use the maid-refactorer subagent to:
 
 1. Ensure tests pass first
 2. Refactor (remove duplication, improve naming, etc.)

--- a/.claude/commands/validate-manifest.md
+++ b/.claude/commands/validate-manifest.md
@@ -5,7 +5,7 @@ argument-hint: [manifest-path]
 
 Validate manifest: $1
 
-Can invoke maid-plan-reviewer agent if tests exist.
+Can use the maid-plan-reviewer subagent if tests exist.
 
 Tasks:
 1. Validate manifest structure: `maid validate $1 --use-manifest-chain`


### PR DESCRIPTION
Updates all custom slash commands in `.claude/commands/` to properly invoke subagents according to the [official Claude Code subagent documentation](https://code.claude.com/docs/en/sub-agents).

### Changes
- Changed "Invokes X agent" to "Use the X subagent"
- Changed "Can invoke X agent" to "Can use the X subagent"
- Changed "Invokes X + Y agents" to "Use the X and Y subagents"

### Files Updated
- audit.md
- fix.md
- generate-manifest.md
- generate-tests.md
- implement.md
- plan.md
- refactor.md
- validate-manifest.md

### Notes
- Subagent files in `.claude/agents/` were already properly formatted with correct YAML frontmatter
- All changes follow the recommended format from the official documentation

Fixes #95

Generated with [Claude Code](https://claude.ai/code)