### PR TITLE
feat: add delete and rename/move support to maid manifest create

### DIFF
--- a/maid_runner/cli/main.py
+++ b/maid_runner/cli/main.py
@@ -337,6 +337,15 @@ Automatically handles:
         action="store_true",
         help="Print manifest without writing to file",
     )
+    manifest_create_parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Create a deletion manifest with status: absent (supersedes all active manifests for the file)",
+    )
+    manifest_create_parser.add_argument(
+        "--rename-to",
+        help="New file path for rename/move operations (supersedes all active manifests for the source file)",
+    )
 
     # Files subcommand
     files_parser = subparsers.add_parser(
@@ -517,6 +526,8 @@ Automatically handles:
                 json_output=args.json,
                 quiet=args.quiet,
                 dry_run=args.dry_run,
+                delete=args.delete,
+                rename_to=args.rename_to,
             )
         else:
             manifest_parser.print_help()

--- a/maid_runner/cli/manifest_create.py
+++ b/maid_runner/cli/manifest_create.py
@@ -33,6 +33,8 @@ def run_create_manifest(
     json_output: bool,
     quiet: bool,
     dry_run: bool,
+    delete: bool = False,
+    rename_to: Optional[str] = None,
 ) -> int:
     """Main entry point for manifest creation, called from main.py CLI.
 
@@ -49,6 +51,8 @@ def run_create_manifest(
         json_output: If True, output created manifest as JSON
         quiet: If True, suppress informational messages
         dry_run: If True, print manifest without writing
+        delete: If True, create a deletion manifest with status: absent
+        rename_to: New file path for rename/move operations
 
     Returns:
         Exit code: 0 on success, non-zero on failure
@@ -67,6 +71,8 @@ def run_create_manifest(
             json_output=json_output,
             quiet=quiet,
             dry_run=dry_run,
+            delete=delete,
+            rename_to=rename_to,
         )
     except Exception as e:
         if json_output:
@@ -94,6 +100,8 @@ def _run_create_manifest_impl(
     json_output: bool,
     quiet: bool,
     dry_run: bool,
+    delete: bool = False,
+    rename_to: Optional[str] = None,
 ) -> int:
     """Implementation of manifest creation logic.
 
@@ -105,13 +113,58 @@ def _run_create_manifest_impl(
     # Convert inputs to proper types (handle both CLI strings and direct Python objects)
     output_dir_path = Path(output_dir) if isinstance(output_dir, str) else output_dir
 
-    # Handle artifacts: string (from CLI) or list (from tests/programmatic)
-    if artifacts is None:
+    # Handle rename_to validation early
+    if rename_to is not None:
+        # Validate rename_to != file_path
+        if rename_to == file_path:
+            raise ValueError(
+                "Cannot rename to the same path. "
+                "--rename-to must be different from the source file."
+            )
+        # Validate not used with delete flag (mutually exclusive)
+        if delete:
+            raise ValueError(
+                "Cannot use --delete and --rename-to together. "
+                "These flags are mutually exclusive."
+            )
+
+    # Handle delete flag validation early
+    if delete:
+        # Validate that artifacts is empty/None when delete=True
+        if artifacts is not None:
+            # Check if it's a non-empty list or non-empty string
+            if isinstance(artifacts, str) and artifacts.strip():
+                raise ValueError(
+                    "Cannot specify artifacts when delete=True. "
+                    "Deletion manifests must have empty artifacts."
+                )
+            elif isinstance(artifacts, list) and len(artifacts) > 0:
+                raise ValueError(
+                    "Cannot specify artifacts when delete=True. "
+                    "Deletion manifests must have empty artifacts."
+                )
+        # Force artifacts to empty list for delete manifests
         artifacts_list = []
-    elif isinstance(artifacts, str):
-        artifacts_list = parse_artifacts_json(artifacts)
+        # Force task_type to "refactor" for delete manifests
+        task_type = "refactor"
+    elif rename_to is not None:
+        # For rename operations, force task_type to "refactor"
+        task_type = "refactor"
+        # Handle artifacts: if not provided, copy from existing manifests
+        if artifacts is None:
+            artifacts_list = _get_artifacts_from_manifests(file_path, output_dir_path)
+        elif isinstance(artifacts, str):
+            artifacts_list = parse_artifacts_json(artifacts)
+        else:
+            artifacts_list = artifacts
     else:
-        artifacts_list = artifacts
+        # Handle artifacts: string (from CLI) or list (from tests/programmatic)
+        if artifacts is None:
+            artifacts_list = []
+        elif isinstance(artifacts, str):
+            artifacts_list = parse_artifacts_json(artifacts)
+        else:
+            artifacts_list = artifacts
 
     # Handle readonly_files: string (from CLI) or list (from tests/programmatic)
     if readonly_files is None:
@@ -127,26 +180,52 @@ def _run_create_manifest_impl(
 
     # Build supersedes list (do this before task type detection)
     supersedes = []
+    active_snapshot = None  # Initialize for later reference in output
 
-    # Auto-supersede active snapshots
-    active_snapshot = _find_active_snapshot_to_supersede(file_path, output_dir_path)
-    if active_snapshot:
-        supersedes.append(active_snapshot)
-        if not quiet and not json_output:
+    if delete:
+        # For delete manifests, auto-supersede ALL active manifests for the file
+        active_manifests = _find_active_manifests_to_supersede(
+            file_path, output_dir_path
+        )
+        supersedes.extend(active_manifests)
+        if active_manifests and not quiet and not json_output:
             print(
-                f"Auto-superseding active snapshot: {active_snapshot}",
+                f"Auto-superseding {len(active_manifests)} active manifest(s): "
+                f"{', '.join(active_manifests)}",
                 file=sys.stderr,
             )
-
-    # Detect or use explicit task type
-    # If superseding a snapshot, the file must exist per MAID methodology
-    # (snapshots are only for existing code), so default to "edit"
-    if task_type is None:
+    elif rename_to is not None:
+        # For rename manifests, auto-supersede ALL active manifests for the OLD file
+        active_manifests = _find_active_manifests_to_supersede(
+            file_path, output_dir_path
+        )
+        supersedes.extend(active_manifests)
+        if active_manifests and not quiet and not json_output:
+            print(
+                f"Auto-superseding {len(active_manifests)} active manifest(s): "
+                f"{', '.join(active_manifests)}",
+                file=sys.stderr,
+            )
+    else:
+        # Auto-supersede active snapshots
+        active_snapshot = _find_active_snapshot_to_supersede(file_path, output_dir_path)
         if active_snapshot:
-            # Superseding a snapshot implies the file exists
-            task_type = "edit"
-        else:
-            task_type = _detect_task_type(Path(file_path))
+            supersedes.append(active_snapshot)
+            if not quiet and not json_output:
+                print(
+                    f"Auto-superseding active snapshot: {active_snapshot}",
+                    file=sys.stderr,
+                )
+
+        # Detect or use explicit task type
+        # If superseding a snapshot, the file must exist per MAID methodology
+        # (snapshots are only for existing code), so default to "edit"
+        if task_type is None:
+            if active_snapshot:
+                # Superseding a snapshot implies the file exists
+                task_type = "edit"
+            else:
+                task_type = _detect_task_type(Path(file_path))
 
     # Add force_supersede if provided
     if force_supersede:
@@ -168,6 +247,8 @@ def _run_create_manifest_impl(
         supersedes=supersedes,
         readonly_files=readonly_list,
         validation_command=validation_command,
+        delete=delete,
+        rename_to=rename_to,
     )
 
     # Generate filename
@@ -308,6 +389,120 @@ def _find_active_snapshot_to_supersede(
     return None
 
 
+def _find_active_manifests_to_supersede(
+    file_path: str, manifests_dir: Path
+) -> List[str]:
+    """Find all active manifests that reference a file.
+
+    Unlike _find_active_snapshot_to_supersede which only finds snapshots,
+    this finds ALL manifest types (snapshot, edit, create, refactor) that
+    reference the given file in expectedArtifacts.
+
+    Args:
+        file_path: Path to the target file (as declared in expectedArtifacts)
+        manifests_dir: Path to the manifests directory
+
+    Returns:
+        List of manifest filenames that reference this file and are not superseded
+    """
+    if not manifests_dir.exists():
+        return []
+
+    # Get set of superseded manifests
+    superseded = get_superseded_manifests(manifests_dir)
+
+    result = []
+    for manifest_path in manifests_dir.glob("task-*.manifest.json"):
+        # Skip already-superseded manifests
+        if manifest_path in superseded:
+            continue
+
+        try:
+            with open(manifest_path, "r") as f:
+                manifest_data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            continue
+
+        # Check if this manifest references our file in expectedArtifacts
+        expected_artifacts = manifest_data.get("expectedArtifacts", {})
+        if not isinstance(expected_artifacts, dict):
+            continue
+
+        manifest_file = expected_artifacts.get("file")
+        if manifest_file == file_path:
+            result.append(manifest_path.name)
+
+    return result
+
+
+def _get_artifacts_from_manifests(
+    file_path: str, manifests_dir: Path
+) -> List[dict]:
+    """Get combined artifacts from all active manifests for a file.
+
+    Used during rename operations to copy existing artifact declarations
+    to the new file location.
+
+    Args:
+        file_path: Path to the file (as declared in expectedArtifacts)
+        manifests_dir: Path to the manifests directory
+
+    Returns:
+        List of artifact dictionaries merged from all active manifests
+    """
+    if not manifests_dir.exists():
+        return []
+
+    # Get set of superseded manifests
+    superseded = get_superseded_manifests(manifests_dir)
+
+    # Collect artifacts from all active manifests for this file
+    all_artifacts = []
+    seen_artifact_keys = set()
+
+    for manifest_path in manifests_dir.glob("task-*.manifest.json"):
+        # Skip already-superseded manifests
+        if manifest_path in superseded:
+            continue
+
+        try:
+            with open(manifest_path, "r") as f:
+                manifest_data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            continue
+
+        # Check if this manifest references our file in expectedArtifacts
+        expected_artifacts = manifest_data.get("expectedArtifacts", {})
+        if not isinstance(expected_artifacts, dict):
+            continue
+
+        manifest_file = expected_artifacts.get("file")
+        if manifest_file != file_path:
+            continue
+
+        # Extract artifacts from contains array
+        contains = expected_artifacts.get("contains", [])
+        if not isinstance(contains, list):
+            continue
+
+        for artifact in contains:
+            if not isinstance(artifact, dict):
+                continue
+
+            # Create a deduplication key based on type, name, and class
+            artifact_key = (
+                artifact.get("type", ""),
+                artifact.get("name", ""),
+                artifact.get("class", ""),
+            )
+
+            if artifact_key not in seen_artifact_keys:
+                seen_artifact_keys.add(artifact_key)
+                all_artifacts.append(artifact)
+
+    return all_artifacts
+
+
 def _generate_manifest(
     goal: str,
     file_path: str,
@@ -316,29 +511,54 @@ def _generate_manifest(
     supersedes: List[str],
     readonly_files: List[str],
     validation_command: List[str],
+    delete: bool = False,
+    rename_to: Optional[str] = None,
 ) -> dict:
     """Build manifest dictionary from provided parameters.
 
     Args:
         goal: Task goal description
-        file_path: Target file path
+        file_path: Target file path (source file for rename operations)
         task_type: One of "create", "edit", "refactor"
         artifacts: List of artifact dictionaries
         supersedes: List of manifest filenames to supersede
         readonly_files: List of readonly dependency paths
         validation_command: Command array for validation
+        delete: If True, create deletion manifest with status: absent
+        rename_to: New file path for rename operations
 
     Returns:
         Complete manifest dictionary
     """
-    # Determine file placement based on task type
-    if task_type == "create":
+    # For delete manifests, always use editableFiles (file exists to be deleted)
+    if delete:
+        creatable_files = []
+        editable_files = [file_path]
+    elif rename_to is not None:
+        # For rename operations: new file in creatableFiles, old file not in any list
+        creatable_files = [rename_to]
+        editable_files = []
+    elif task_type == "create":
         creatable_files = [file_path]
         editable_files = []
     else:
         # edit, refactor, etc. use editableFiles
         creatable_files = []
         editable_files = [file_path]
+
+    # Determine the file path for expectedArtifacts
+    # For rename: use the new path; otherwise use the original path
+    artifacts_file = rename_to if rename_to is not None else file_path
+
+    # Build expectedArtifacts
+    expected_artifacts = {
+        "file": artifacts_file,
+        "contains": artifacts,
+    }
+
+    # For delete manifests, add status: absent
+    if delete:
+        expected_artifacts["status"] = "absent"
 
     return {
         "goal": goal,
@@ -347,10 +567,7 @@ def _generate_manifest(
         "creatableFiles": creatable_files,
         "editableFiles": editable_files,
         "readonlyFiles": readonly_files,
-        "expectedArtifacts": {
-            "file": file_path,
-            "contains": artifacts,
-        },
+        "expectedArtifacts": expected_artifacts,
         "validationCommand": validation_command,
     }
 

--- a/manifests/task-098-add-delete-flag-manifest-create.manifest.json
+++ b/manifests/task-098-add-delete-flag-manifest-create.manifest.json
@@ -1,0 +1,105 @@
+{
+  "goal": "Add --delete flag support to maid manifest create command for creating deletion manifests with status: absent",
+  "taskType": "edit",
+  "supersedes": ["task-097-manifest-create-core.manifest.json"],
+  "editableFiles": [
+    "maid_runner/cli/manifest_create.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/cli/main.py",
+    "maid_runner/utils.py",
+    "docs/maid_specs.md",
+    "maid_runner/validators/schemas/manifest.schema.json"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/manifest_create.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "run_create_manifest",
+        "description": "Main entry point for manifest creation with delete flag support",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "goal", "type": "str"},
+          {"name": "artifacts", "type": "Optional[Union[str, List[dict]]]"},
+          {"name": "task_type", "type": "Optional[str]"},
+          {"name": "force_supersede", "type": "Optional[str]"},
+          {"name": "test_file", "type": "Optional[str]"},
+          {"name": "readonly_files", "type": "Optional[Union[str, List[str]]]"},
+          {"name": "output_dir", "type": "Union[str, Path]"},
+          {"name": "task_number", "type": "Optional[int]"},
+          {"name": "json_output", "type": "bool"},
+          {"name": "quiet", "type": "bool"},
+          {"name": "dry_run", "type": "bool"},
+          {"name": "delete", "type": "bool"}
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "_get_next_task_number",
+        "description": "Find next available task number by scanning manifest directory",
+        "args": [
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "_detect_task_type",
+        "description": "Auto-detect create/edit based on file existence",
+        "args": [
+          {"name": "file_path", "type": "Path"}
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_find_active_snapshot_to_supersede",
+        "description": "Find active snapshot manifest that must be superseded to edit file",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_find_active_manifests_to_supersede",
+        "description": "Find all active manifests referencing a file that should be superseded for deletion",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "List[str]"
+      },
+      {
+        "type": "function",
+        "name": "_generate_manifest",
+        "description": "Build manifest dictionary from provided parameters with delete support",
+        "args": [
+          {"name": "goal", "type": "str"},
+          {"name": "file_path", "type": "str"},
+          {"name": "task_type", "type": "str"},
+          {"name": "artifacts", "type": "List[dict]"},
+          {"name": "supersedes", "type": "List[str]"},
+          {"name": "readonly_files", "type": "List[str]"},
+          {"name": "validation_command", "type": "List[str]"},
+          {"name": "delete", "type": "bool"}
+        ],
+        "returns": "dict"
+      },
+      {
+        "type": "function",
+        "name": "_write_manifest",
+        "description": "Write manifest dictionary to JSON file",
+        "args": [
+          {"name": "manifest_data", "type": "dict"},
+          {"name": "output_path", "type": "Path"}
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_097_manifest_create.py", "tests/test_task_098_delete_flag.py", "-v"]
+}

--- a/manifests/task-099-add-rename-to-flag-manifest-create.manifest.json
+++ b/manifests/task-099-add-rename-to-flag-manifest-create.manifest.json
@@ -1,0 +1,117 @@
+{
+  "goal": "Add --rename-to flag support to maid manifest create command for creating rename/move manifests",
+  "taskType": "edit",
+  "supersedes": ["task-098-add-delete-flag-manifest-create.manifest.json"],
+  "editableFiles": [
+    "maid_runner/cli/manifest_create.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/cli/main.py",
+    "maid_runner/utils.py",
+    "docs/maid_specs.md",
+    "maid_runner/validators/schemas/manifest.schema.json"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/manifest_create.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "run_create_manifest",
+        "description": "Main entry point for manifest creation with rename_to support",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "goal", "type": "str"},
+          {"name": "artifacts", "type": "Optional[Union[str, List[dict]]]"},
+          {"name": "task_type", "type": "Optional[str]"},
+          {"name": "force_supersede", "type": "Optional[str]"},
+          {"name": "test_file", "type": "Optional[str]"},
+          {"name": "readonly_files", "type": "Optional[Union[str, List[str]]]"},
+          {"name": "output_dir", "type": "Union[str, Path]"},
+          {"name": "task_number", "type": "Optional[int]"},
+          {"name": "json_output", "type": "bool"},
+          {"name": "quiet", "type": "bool"},
+          {"name": "dry_run", "type": "bool"},
+          {"name": "delete", "type": "bool"},
+          {"name": "rename_to", "type": "Optional[str]"}
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "_get_artifacts_from_manifests",
+        "description": "Get combined artifacts from all active manifests for a file, used during rename to copy existing artifact declarations to new location",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "List[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_next_task_number",
+        "description": "Find next available task number by scanning manifest directory",
+        "args": [
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "_detect_task_type",
+        "description": "Auto-detect create/edit based on file existence",
+        "args": [
+          {"name": "file_path", "type": "Path"}
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_find_active_snapshot_to_supersede",
+        "description": "Find active snapshot manifest that must be superseded to edit file",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_find_active_manifests_to_supersede",
+        "description": "Find all active manifests referencing a file that should be superseded for deletion or rename",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "manifests_dir", "type": "Path"}
+        ],
+        "returns": "List[str]"
+      },
+      {
+        "type": "function",
+        "name": "_generate_manifest",
+        "description": "Build manifest dictionary from provided parameters with delete and rename support",
+        "args": [
+          {"name": "goal", "type": "str"},
+          {"name": "file_path", "type": "str"},
+          {"name": "task_type", "type": "str"},
+          {"name": "artifacts", "type": "List[dict]"},
+          {"name": "supersedes", "type": "List[str]"},
+          {"name": "readonly_files", "type": "List[str]"},
+          {"name": "validation_command", "type": "List[str]"},
+          {"name": "delete", "type": "bool"},
+          {"name": "rename_to", "type": "Optional[str]"}
+        ],
+        "returns": "dict"
+      },
+      {
+        "type": "function",
+        "name": "_write_manifest",
+        "description": "Write manifest dictionary to JSON file",
+        "args": [
+          {"name": "manifest_data", "type": "dict"},
+          {"name": "output_path", "type": "Path"}
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_097_manifest_create.py", "tests/test_task_098_delete_flag.py", "tests/test_task_099_rename_to_flag.py", "-v"]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,11 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add project root to path for importing scripts
 _project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(_project_root))
-
-import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_task_098_delete_flag.py
+++ b/tests/test_task_098_delete_flag.py
@@ -1,0 +1,568 @@
+"""Behavioral tests for task-098: Delete flag support in `maid manifest create` command.
+
+These tests verify the --delete flag functionality for creating deletion manifests:
+- run_create_manifest() with delete=True parameter
+- _find_active_manifests_to_supersede() helper function
+
+Tests focus on actual behavior (inputs/outputs), not implementation details.
+"""
+
+import json
+
+import pytest
+
+from maid_runner.cli.manifest_create import (
+    run_create_manifest,
+    _find_active_manifests_to_supersede,
+)
+
+
+class TestRunCreateManifestWithDeleteFlag:
+    """Tests for run_create_manifest() with delete=True parameter."""
+
+    def test_delete_flag_sets_task_type_refactor(self, tmp_path):
+        """When delete=True, manifest should have taskType='refactor'."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create an existing file to delete
+        target_file = tmp_path / "src" / "service.py"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text("def serve(): pass")
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        # Find created manifest
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        assert len(manifests) == 1
+
+        data = json.loads(manifests[0].read_text())
+        assert data["taskType"] == "refactor"
+
+    def test_delete_flag_sets_status_absent(self, tmp_path):
+        """When delete=True, expectedArtifacts.status should be 'absent'."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        assert len(manifests) == 1
+
+        data = json.loads(manifests[0].read_text())
+        assert data["expectedArtifacts"]["status"] == "absent"
+
+    def test_delete_flag_enforces_empty_artifacts(self, tmp_path, capsys):
+        """When delete=True and artifacts provided, should raise ValueError."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        with pytest.raises(ValueError, match="artifacts"):
+            run_create_manifest(
+                file_path="src/service.py",
+                goal="Delete service module",
+                artifacts=[{"type": "function", "name": "serve"}],
+                task_type=None,
+                force_supersede=None,
+                test_file=None,
+                readonly_files=None,
+                output_dir=manifests_dir,
+                task_number=None,
+                json_output=False,
+                quiet=True,
+                dry_run=False,
+                delete=True,
+            )
+
+    def test_delete_flag_uses_editable_files(self, tmp_path):
+        """When delete=True, file should be in editableFiles (not creatableFiles)."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        assert "src/service.py" in data["editableFiles"]
+        assert data["creatableFiles"] == []
+
+    def test_delete_flag_has_empty_contains(self, tmp_path):
+        """When delete=True, expectedArtifacts.contains should be []."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        assert data["expectedArtifacts"]["contains"] == []
+
+    def test_delete_flag_auto_supersedes_active_manifests(self, tmp_path):
+        """When delete=True, should find and supersede all active manifests for the file."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create active snapshot manifest for target file
+        snapshot_data = {
+            "goal": "Snapshot service",
+            "taskType": "snapshot",
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-010-snapshot-service.manifest.json").write_text(
+            json.dumps(snapshot_data)
+        )
+
+        # Create active edit manifest for target file
+        edit_data = {
+            "goal": "Edit service",
+            "taskType": "edit",
+            "supersedes": ["task-010-snapshot-service.manifest.json"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-020-edit-service.manifest.json").write_text(
+            json.dumps(edit_data)
+        )
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        # Find created manifest (not the snapshot or edit)
+        created_manifests = [
+            m
+            for m in manifests_dir.glob("task-*.manifest.json")
+            if "snapshot-service" not in m.name and "edit-service" not in m.name
+        ]
+        assert len(created_manifests) == 1
+
+        data = json.loads(created_manifests[0].read_text())
+
+        # Should supersede the active edit manifest (not the already-superseded snapshot)
+        assert "task-020-edit-service.manifest.json" in data["supersedes"]
+
+
+class TestFindActiveManifestsToSupersede:
+    """Tests for _find_active_manifests_to_supersede() function."""
+
+    def test_finds_snapshot_manifests_for_file(self, tmp_path):
+        """Should find snapshot manifests referencing the file."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create a snapshot manifest for our target file
+        snapshot_data = {
+            "goal": "Snapshot service",
+            "taskType": "snapshot",
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-010-snapshot-service.manifest.json").write_text(
+            json.dumps(snapshot_data)
+        )
+
+        result = _find_active_manifests_to_supersede("src/service.py", manifests_dir)
+
+        assert "task-010-snapshot-service.manifest.json" in result
+
+    def test_finds_edit_manifests_for_file(self, tmp_path):
+        """Should find edit/create manifests referencing the file."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create an edit manifest for our target file
+        edit_data = {
+            "goal": "Edit service",
+            "taskType": "edit",
+            "editableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-015-edit-service.manifest.json").write_text(
+            json.dumps(edit_data)
+        )
+
+        # Create a create manifest for our target file
+        create_data = {
+            "goal": "Create service",
+            "taskType": "create",
+            "creatableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "class", "name": "Service"}],
+            },
+        }
+        (manifests_dir / "task-016-create-service.manifest.json").write_text(
+            json.dumps(create_data)
+        )
+
+        result = _find_active_manifests_to_supersede("src/service.py", manifests_dir)
+
+        assert "task-015-edit-service.manifest.json" in result
+        assert "task-016-create-service.manifest.json" in result
+
+    def test_excludes_already_superseded_manifests(self, tmp_path):
+        """Should not include manifests that are already superseded."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create an old snapshot (will be superseded)
+        old_snapshot = {
+            "goal": "Old snapshot",
+            "taskType": "snapshot",
+            "expectedArtifacts": {"file": "src/service.py", "contains": []},
+        }
+        (manifests_dir / "task-010-old-snapshot.manifest.json").write_text(
+            json.dumps(old_snapshot)
+        )
+
+        # Create a manifest that supersedes the old snapshot
+        superseding_manifest = {
+            "goal": "Edit service",
+            "taskType": "edit",
+            "supersedes": ["task-010-old-snapshot.manifest.json"],
+            "expectedArtifacts": {"file": "src/service.py", "contains": []},
+        }
+        (manifests_dir / "task-015-edit-service.manifest.json").write_text(
+            json.dumps(superseding_manifest)
+        )
+
+        result = _find_active_manifests_to_supersede("src/service.py", manifests_dir)
+
+        # Should include the edit manifest but not the superseded snapshot
+        assert "task-015-edit-service.manifest.json" in result
+        assert "task-010-old-snapshot.manifest.json" not in result
+
+    def test_returns_empty_when_no_manifests(self, tmp_path):
+        """Returns empty list when no manifests reference the file."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create a manifest for a different file
+        other_data = {
+            "goal": "Edit other",
+            "taskType": "edit",
+            "expectedArtifacts": {"file": "src/other.py", "contains": []},
+        }
+        (manifests_dir / "task-010-edit-other.manifest.json").write_text(
+            json.dumps(other_data)
+        )
+
+        result = _find_active_manifests_to_supersede("src/service.py", manifests_dir)
+
+        assert result == []
+
+    def test_handles_missing_manifest_directory(self, tmp_path):
+        """Returns empty list when manifest directory doesn't exist."""
+        manifests_dir = tmp_path / "manifests"
+        # Directory not created
+
+        result = _find_active_manifests_to_supersede("src/service.py", manifests_dir)
+
+        assert result == []
+
+
+class TestDeleteFlagWithJsonOutput:
+    """Tests for JSON output mode with delete flag."""
+
+    def test_delete_json_output_includes_status(self, tmp_path, capsys):
+        """JSON output should show status: 'absent' in manifest."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is True
+        assert output["manifest"]["expectedArtifacts"]["status"] == "absent"
+
+
+class TestDeleteFlagWithDryRun:
+    """Tests for dry-run mode with delete flag."""
+
+    def test_delete_dry_run_shows_absent_status(self, tmp_path, capsys):
+        """Dry run output should preview the deletion manifest correctly."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=False,
+            dry_run=True,
+            delete=True,
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["dry_run"] is True
+        assert output["manifest"]["taskType"] == "refactor"
+        assert output["manifest"]["expectedArtifacts"]["status"] == "absent"
+        assert output["manifest"]["expectedArtifacts"]["contains"] == []
+
+        # No manifest file should be created
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        assert len(manifests) == 0
+
+
+class TestDeleteFlagErrorHandling:
+    """Tests for error handling with delete flag."""
+
+    def test_delete_with_artifacts_json_output_returns_error(self, tmp_path, capsys):
+        """When json_output=True and artifacts provided with delete, returns JSON error."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Delete service module",
+            artifacts=[{"type": "function", "name": "serve"}],
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 1  # Non-zero exit code
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is False
+        assert "error" in output
+        assert "artifacts" in output["error"].lower()
+
+
+class TestDeleteFlagWithExistingManifests:
+    """Integration tests for delete flag with existing manifest chains."""
+
+    def test_delete_creates_proper_manifest_chain(self, tmp_path):
+        """Delete manifest properly supersedes and creates valid chain."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create original create manifest
+        create_data = {
+            "goal": "Create service module",
+            "taskType": "create",
+            "creatableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-001-create-service.manifest.json").write_text(
+            json.dumps(create_data)
+        )
+
+        # Create edit manifest
+        edit_data = {
+            "goal": "Add logging to service",
+            "taskType": "edit",
+            "editableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [
+                    {"type": "function", "name": "serve"},
+                    {"type": "function", "name": "log"},
+                ],
+            },
+        }
+        (manifests_dir / "task-002-add-logging.manifest.json").write_text(
+            json.dumps(edit_data)
+        )
+
+        # Now delete the file
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Remove deprecated service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+        )
+
+        assert result == 0
+
+        # Find the delete manifest
+        delete_manifests = [
+            m
+            for m in manifests_dir.glob("task-*.manifest.json")
+            if "create-service" not in m.name and "add-logging" not in m.name
+        ]
+        assert len(delete_manifests) == 1
+
+        data = json.loads(delete_manifests[0].read_text())
+
+        # Verify deletion manifest structure
+        assert data["taskType"] == "refactor"
+        assert data["expectedArtifacts"]["status"] == "absent"
+        assert data["expectedArtifacts"]["contains"] == []
+        assert "src/service.py" in data["editableFiles"]
+
+        # Should supersede both active manifests that reference this file
+        assert "task-001-create-service.manifest.json" in data["supersedes"]
+        assert "task-002-add-logging.manifest.json" in data["supersedes"]
+
+    def test_delete_flag_default_false(self, tmp_path):
+        """By default, delete flag should be False (normal manifest creation)."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create without delete flag - using positional args that existed before
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Add feature",
+            artifacts=[{"type": "function", "name": "new_func"}],
+            task_type="create",
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        # Should NOT have status: absent
+        assert "status" not in data["expectedArtifacts"]
+        # Should have artifacts in contains
+        assert len(data["expectedArtifacts"]["contains"]) == 1

--- a/tests/test_task_099_rename_to_flag.py
+++ b/tests/test_task_099_rename_to_flag.py
@@ -1,0 +1,781 @@
+"""Behavioral tests for task-099: Rename-to flag support in `maid manifest create` command.
+
+These tests verify the --rename-to flag functionality for creating rename/move manifests:
+- run_create_manifest() with rename_to parameter
+- _get_artifacts_from_manifests() helper function
+
+Tests focus on actual behavior (inputs/outputs), not implementation details.
+"""
+
+import json
+
+from maid_runner.cli.manifest_create import (
+    run_create_manifest,
+    _get_artifacts_from_manifests,
+)
+
+
+class TestRunCreateManifestWithRenameTo:
+    """Tests for run_create_manifest() with rename_to parameter."""
+
+    def test_rename_to_sets_task_type_refactor(self, tmp_path):
+        """When rename_to is provided, manifest should have taskType='refactor'."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        # Find created manifest
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        assert len(manifests) == 1
+
+        data = json.loads(manifests[0].read_text())
+        assert data["taskType"] == "refactor"
+
+    def test_rename_to_uses_creatable_files_for_new_path(self, tmp_path):
+        """New file path (rename_to) should be in creatableFiles."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        # New file path should be in creatableFiles
+        assert "src/new_service.py" in data["creatableFiles"]
+
+    def test_rename_to_old_file_not_in_file_lists(self, tmp_path):
+        """Old file path should NOT be in creatableFiles or editableFiles."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        # Old file should NOT be in creatableFiles or editableFiles
+        assert "src/old_service.py" not in data["creatableFiles"]
+        assert "src/old_service.py" not in data["editableFiles"]
+
+    def test_rename_to_auto_supersedes_active_manifests(self, tmp_path):
+        """Should supersede all active manifests for the OLD file."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create active snapshot manifest for OLD file path
+        snapshot_data = {
+            "goal": "Snapshot old service",
+            "taskType": "snapshot",
+            "expectedArtifacts": {
+                "file": "src/old_service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-010-snapshot-service.manifest.json").write_text(
+            json.dumps(snapshot_data)
+        )
+
+        # Create active edit manifest for OLD file path
+        edit_data = {
+            "goal": "Edit old service",
+            "taskType": "edit",
+            "supersedes": ["task-010-snapshot-service.manifest.json"],
+            "expectedArtifacts": {
+                "file": "src/old_service.py",
+                "contains": [
+                    {"type": "function", "name": "serve"},
+                    {"type": "function", "name": "log"},
+                ],
+            },
+        }
+        (manifests_dir / "task-020-edit-service.manifest.json").write_text(
+            json.dumps(edit_data)
+        )
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        # Find created manifest (not the snapshot or edit)
+        created_manifests = [
+            m
+            for m in manifests_dir.glob("task-*.manifest.json")
+            if "snapshot-service" not in m.name and "edit-service" not in m.name
+        ]
+        assert len(created_manifests) == 1
+
+        data = json.loads(created_manifests[0].read_text())
+
+        # Should supersede the active edit manifest (not the already-superseded snapshot)
+        assert "task-020-edit-service.manifest.json" in data["supersedes"]
+
+    def test_rename_to_copies_artifacts_from_old_manifests(self, tmp_path):
+        """When no --artifacts provided, should copy from existing manifests."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create active manifest with artifacts for OLD file path
+        existing_data = {
+            "goal": "Create old service",
+            "taskType": "create",
+            "creatableFiles": ["src/old_service.py"],
+            "expectedArtifacts": {
+                "file": "src/old_service.py",
+                "contains": [
+                    {"type": "class", "name": "OldService"},
+                    {"type": "function", "name": "process", "class": "OldService"},
+                ],
+            },
+        }
+        (manifests_dir / "task-010-create-service.manifest.json").write_text(
+            json.dumps(existing_data)
+        )
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=None,  # No explicit artifacts - should copy from existing
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        # Find created manifest
+        created_manifests = [
+            m
+            for m in manifests_dir.glob("task-*.manifest.json")
+            if "create-service" not in m.name
+        ]
+        assert len(created_manifests) == 1
+
+        data = json.loads(created_manifests[0].read_text())
+
+        # Should have copied artifacts from existing manifest
+        contains = data["expectedArtifacts"]["contains"]
+        assert len(contains) >= 1
+        artifact_names = [a["name"] for a in contains]
+        assert "OldService" in artifact_names or "process" in artifact_names
+
+    def test_rename_to_uses_provided_artifacts_when_given(self, tmp_path):
+        """When --artifacts provided, use those instead of copying."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create existing manifest with OLD artifacts
+        existing_data = {
+            "goal": "Create old service",
+            "taskType": "create",
+            "creatableFiles": ["src/old_service.py"],
+            "expectedArtifacts": {
+                "file": "src/old_service.py",
+                "contains": [{"type": "class", "name": "OldService"}],
+            },
+        }
+        (manifests_dir / "task-010-create-service.manifest.json").write_text(
+            json.dumps(existing_data)
+        )
+
+        # Provide explicit new artifacts
+        new_artifacts = [
+            {"type": "class", "name": "NewService"},
+            {"type": "function", "name": "new_process"},
+        ]
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename and refactor service module",
+            artifacts=new_artifacts,  # Explicit artifacts
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        # Find created manifest
+        created_manifests = [
+            m
+            for m in manifests_dir.glob("task-*.manifest.json")
+            if "create-service" not in m.name
+        ]
+        assert len(created_manifests) == 1
+
+        data = json.loads(created_manifests[0].read_text())
+
+        # Should use provided artifacts, not copied ones
+        contains = data["expectedArtifacts"]["contains"]
+        artifact_names = [a["name"] for a in contains]
+        assert "NewService" in artifact_names
+        assert "new_process" in artifact_names
+        # Should NOT have old artifacts
+        assert "OldService" not in artifact_names
+
+    def test_rename_to_expected_artifacts_references_new_file(self, tmp_path):
+        """expectedArtifacts.file should be the NEW file path."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=[{"type": "function", "name": "serve"}],
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        # expectedArtifacts.file should reference the NEW path
+        assert data["expectedArtifacts"]["file"] == "src/new_service.py"
+
+
+class TestGetArtifactsFromManifests:
+    """Tests for _get_artifacts_from_manifests() function."""
+
+    def test_gets_artifacts_from_snapshot_manifest(self, tmp_path):
+        """Should extract artifacts from snapshot manifests."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create a snapshot manifest with artifacts
+        snapshot_data = {
+            "goal": "Snapshot service",
+            "taskType": "snapshot",
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [
+                    {"type": "function", "name": "serve"},
+                    {"type": "class", "name": "Server"},
+                ],
+            },
+        }
+        (manifests_dir / "task-010-snapshot-service.manifest.json").write_text(
+            json.dumps(snapshot_data)
+        )
+
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        assert len(result) == 2
+        artifact_names = [a["name"] for a in result]
+        assert "serve" in artifact_names
+        assert "Server" in artifact_names
+
+    def test_gets_artifacts_from_edit_manifest(self, tmp_path):
+        """Should extract artifacts from edit manifests."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create an edit manifest with artifacts
+        edit_data = {
+            "goal": "Edit service",
+            "taskType": "edit",
+            "editableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [
+                    {"type": "function", "name": "process"},
+                    {"type": "function", "name": "validate"},
+                ],
+            },
+        }
+        (manifests_dir / "task-015-edit-service.manifest.json").write_text(
+            json.dumps(edit_data)
+        )
+
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        assert len(result) == 2
+        artifact_names = [a["name"] for a in result]
+        assert "process" in artifact_names
+        assert "validate" in artifact_names
+
+    def test_merges_artifacts_from_multiple_manifests(self, tmp_path):
+        """Should combine artifacts from multiple active manifests."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create first manifest with some artifacts
+        first_data = {
+            "goal": "Create service",
+            "taskType": "create",
+            "creatableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "serve"}],
+            },
+        }
+        (manifests_dir / "task-010-create-service.manifest.json").write_text(
+            json.dumps(first_data)
+        )
+
+        # Create second manifest with additional artifacts
+        second_data = {
+            "goal": "Add logging",
+            "taskType": "edit",
+            "editableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "log"}],
+            },
+        }
+        (manifests_dir / "task-020-add-logging.manifest.json").write_text(
+            json.dumps(second_data)
+        )
+
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        # Should have artifacts from both manifests
+        artifact_names = [a["name"] for a in result]
+        assert "serve" in artifact_names
+        assert "log" in artifact_names
+
+    def test_excludes_superseded_manifest_artifacts(self, tmp_path):
+        """Should not include artifacts from superseded manifests."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create old manifest (will be superseded)
+        old_data = {
+            "goal": "Old service",
+            "taskType": "create",
+            "creatableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "old_func"}],
+            },
+        }
+        (manifests_dir / "task-010-old-service.manifest.json").write_text(
+            json.dumps(old_data)
+        )
+
+        # Create new manifest that supersedes the old one
+        new_data = {
+            "goal": "Rewrite service",
+            "taskType": "edit",
+            "supersedes": ["task-010-old-service.manifest.json"],
+            "editableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                "contains": [{"type": "function", "name": "new_func"}],
+            },
+        }
+        (manifests_dir / "task-020-rewrite-service.manifest.json").write_text(
+            json.dumps(new_data)
+        )
+
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        artifact_names = [a["name"] for a in result]
+        # Should NOT include old_func (from superseded manifest)
+        assert "old_func" not in artifact_names
+        # Should include new_func (from active manifest)
+        assert "new_func" in artifact_names
+
+    def test_returns_empty_when_no_manifests(self, tmp_path):
+        """Returns empty list when no manifests exist for file."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create manifest for a DIFFERENT file
+        other_data = {
+            "goal": "Other module",
+            "taskType": "create",
+            "creatableFiles": ["src/other.py"],
+            "expectedArtifacts": {
+                "file": "src/other.py",
+                "contains": [{"type": "function", "name": "other_func"}],
+            },
+        }
+        (manifests_dir / "task-010-other.manifest.json").write_text(
+            json.dumps(other_data)
+        )
+
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        assert result == []
+
+    def test_handles_missing_manifest_directory(self, tmp_path):
+        """Returns empty list when manifest directory doesn't exist."""
+        manifests_dir = tmp_path / "manifests"
+        # Directory not created
+
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        assert result == []
+
+    def test_handles_manifest_without_contains(self, tmp_path):
+        """Gracefully handles manifests with missing contains array."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create manifest without contains array
+        malformed_data = {
+            "goal": "Malformed manifest",
+            "taskType": "edit",
+            "editableFiles": ["src/service.py"],
+            "expectedArtifacts": {
+                "file": "src/service.py",
+                # Missing "contains" array
+            },
+        }
+        (manifests_dir / "task-010-malformed.manifest.json").write_text(
+            json.dumps(malformed_data)
+        )
+
+        # Should not crash
+        result = _get_artifacts_from_manifests("src/service.py", manifests_dir)
+
+        # Should return empty list (no artifacts found)
+        assert result == []
+
+
+class TestRenameToWithJsonOutput:
+    """Tests for JSON output mode with rename_to flag."""
+
+    def test_rename_json_output_shows_new_file_in_creatable(self, tmp_path, capsys):
+        """JSON output shows new file in creatableFiles."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=[{"type": "function", "name": "serve"}],
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is True
+        assert "src/new_service.py" in output["manifest"]["creatableFiles"]
+        assert output["manifest"]["expectedArtifacts"]["file"] == "src/new_service.py"
+
+
+class TestRenameToWithDryRun:
+    """Tests for dry-run mode with rename_to flag."""
+
+    def test_rename_dry_run_shows_correct_structure(self, tmp_path, capsys):
+        """Dry run previews rename manifest correctly."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        result = run_create_manifest(
+            file_path="src/old_service.py",
+            goal="Rename service module",
+            artifacts=[{"type": "function", "name": "serve"}],
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=False,
+            dry_run=True,
+            delete=False,
+            rename_to="src/new_service.py",
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["dry_run"] is True
+        assert output["manifest"]["taskType"] == "refactor"
+        assert "src/new_service.py" in output["manifest"]["creatableFiles"]
+        assert output["manifest"]["expectedArtifacts"]["file"] == "src/new_service.py"
+
+        # No manifest file should be created
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        assert len(manifests) == 0
+
+
+class TestRenameToErrorHandling:
+    """Tests for error handling with rename_to flag."""
+
+    def test_rename_to_same_path_error(self, tmp_path, capsys):
+        """Should error if rename_to is same as file_path."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Using JSON output to capture error
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Rename to same path",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/service.py",  # Same as file_path
+        )
+
+        assert result == 1  # Non-zero exit code
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is False
+        assert "error" in output
+
+    def test_rename_to_and_delete_mutually_exclusive(self, tmp_path, capsys):
+        """Should error if both --delete and --rename-to provided."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Using JSON output to capture error
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Invalid operation",
+            artifacts=None,
+            task_type=None,
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=True,
+            quiet=True,
+            dry_run=False,
+            delete=True,
+            rename_to="src/new_service.py",  # Both delete and rename_to
+        )
+
+        assert result == 1  # Non-zero exit code
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is False
+        assert "error" in output
+
+
+class TestRenameToIntegration:
+    """Integration tests for rename_to flag."""
+
+    def test_rename_creates_valid_manifest_structure(self, tmp_path):
+        """Full integration test verifying the manifest structure."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create existing manifest to supersede
+        existing_data = {
+            "goal": "Create auth module",
+            "taskType": "create",
+            "creatableFiles": ["src/auth/old_auth.py"],
+            "expectedArtifacts": {
+                "file": "src/auth/old_auth.py",
+                "contains": [
+                    {"type": "class", "name": "AuthHandler"},
+                    {"type": "function", "name": "authenticate", "class": "AuthHandler"},
+                ],
+            },
+        }
+        (manifests_dir / "task-050-create-auth.manifest.json").write_text(
+            json.dumps(existing_data)
+        )
+
+        result = run_create_manifest(
+            file_path="src/auth/old_auth.py",
+            goal="Rename auth module to better location",
+            artifacts=None,  # Should copy from existing
+            task_type=None,
+            force_supersede=None,
+            test_file="tests/test_auth.py",
+            readonly_files=["src/config.py"],
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to="src/authentication/handler.py",
+        )
+
+        assert result == 0
+
+        # Find the created rename manifest
+        created_manifests = [
+            m
+            for m in manifests_dir.glob("task-*.manifest.json")
+            if "create-auth" not in m.name
+        ]
+        assert len(created_manifests) == 1
+
+        data = json.loads(created_manifests[0].read_text())
+
+        # Verify manifest structure
+        assert data["goal"] == "Rename auth module to better location"
+        assert data["taskType"] == "refactor"
+
+        # New path in creatableFiles
+        assert "src/authentication/handler.py" in data["creatableFiles"]
+        # Old path NOT in file lists
+        assert "src/auth/old_auth.py" not in data["creatableFiles"]
+        assert "src/auth/old_auth.py" not in data["editableFiles"]
+
+        # Supersedes the old manifest
+        assert "task-050-create-auth.manifest.json" in data["supersedes"]
+
+        # expectedArtifacts references new path
+        assert data["expectedArtifacts"]["file"] == "src/authentication/handler.py"
+
+        # Has readonly files
+        assert "src/config.py" in data["readonlyFiles"]
+
+        # Has validation command with test file
+        assert "tests/test_auth.py" in data["validationCommand"]
+
+    def test_rename_to_default_none(self, tmp_path):
+        """Verifies rename_to=None is the default behavior (normal manifest creation)."""
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create without rename_to - should behave like normal manifest creation
+        result = run_create_manifest(
+            file_path="src/service.py",
+            goal="Add feature",
+            artifacts=[{"type": "function", "name": "new_func"}],
+            task_type="create",
+            force_supersede=None,
+            test_file=None,
+            readonly_files=None,
+            output_dir=manifests_dir,
+            task_number=None,
+            json_output=False,
+            quiet=True,
+            dry_run=False,
+            delete=False,
+            rename_to=None,  # Explicitly None (default)
+        )
+
+        assert result == 0
+
+        manifests = list(manifests_dir.glob("task-*.manifest.json"))
+        data = json.loads(manifests[0].read_text())
+
+        # Should behave like normal create manifest
+        assert data["taskType"] == "create"
+        assert "src/service.py" in data["creatableFiles"]
+        assert data["expectedArtifacts"]["file"] == "src/service.py"
+        # Should have the artifact
+        assert len(data["expectedArtifacts"]["contains"]) == 1
+        assert data["expectedArtifacts"]["contains"][0]["name"] == "new_func"


### PR DESCRIPTION
Implements GitHub issue #102 with two new flags:

--delete: Creates deletion manifests with status: "absent"
  - Forces taskType to "refactor"
  - Auto-supersedes all active manifests for the file
  - Validates artifacts are empty

--rename-to: Creates rename/move manifests
  - Forces taskType to "refactor"
  - Auto-supersedes active manifests for old file
  - Copies artifacts from old manifests to new location
  - New file goes in creatableFiles

Includes 36 behavioral tests (16 for delete, 20 for rename).