### PR TITLE
fix: close test file bypass security loophole (issue #100)

### DIFF
--- a/maid_runner/validators/_artifact_validation.py
+++ b/maid_runner/validators/_artifact_validation.py
@@ -58,18 +58,44 @@ def _validate_all_artifacts(
         _validate_single_artifact(artifact, collector, validation_mode)
 
 
-def _check_unexpected_artifacts(expected_items: List[dict], collector: Any) -> None:
+def _is_test_file_path(path: str) -> bool:
+    """Check if file path indicates a test file.
+
+    A file is considered a test file if:
+    - It's in a 'tests/' directory, OR
+    - Its filename starts with 'test_'
+
+    Args:
+        path: File path to check
+
+    Returns:
+        True if this is a test file path
+    """
+    # Normalize path separators
+    normalized = path.replace("\\", "/")
+    # Check if in tests directory
+    if normalized.startswith("tests/") or "/tests/" in normalized:
+        return True
+    # Check if filename starts with test_
+    filename = normalized.split("/")[-1]
+    return filename.startswith("test_")
+
+
+def _check_unexpected_artifacts(
+    expected_items: List[dict], collector: Any, file_path: str
+) -> None:
     """Check for unexpected public artifacts in strict mode.
 
     Args:
         expected_items: List of expected artifacts
         collector: Artifact collector with discovered artifacts
+        file_path: Path to the file being validated
 
     Raises:
         AlignmentError: If unexpected public artifacts are found
     """
-    # Skip strict validation for test files
-    is_test_file = any(func.startswith("test_") for func in collector.found_functions)
+    # Skip strict validation for test files (path-based detection)
+    is_test_file = _is_test_file_path(file_path)
 
     if expected_items and not is_test_file:
         _validate_no_unexpected_artifacts(

--- a/maid_runner/validators/manifest_validator.py
+++ b/maid_runner/validators/manifest_validator.py
@@ -300,7 +300,7 @@ def validate_with_ast(
     _validate_all_artifacts(expected_items, collector, validation_mode)
 
     # Check for unexpected public artifacts (strict mode)
-    _check_unexpected_artifacts(expected_items, collector)
+    _check_unexpected_artifacts(expected_items, collector, test_file_path)
 
     # Type hint validation (only in implementation mode)
     if validation_mode == _VALIDATION_MODE_IMPLEMENTATION:
@@ -1077,10 +1077,12 @@ def _validate_all_artifacts(
 
 
 def _check_unexpected_artifacts(
-    expected_items: List[dict], collector: "_ArtifactCollector"
+    expected_items: List[dict], collector: "_ArtifactCollector", file_path: str
 ) -> None:
     """Check for unexpected public artifacts in strict mode."""
-    return _artifact_validation._check_unexpected_artifacts(expected_items, collector)
+    return _artifact_validation._check_unexpected_artifacts(
+        expected_items, collector, file_path
+    )
 
 
 def _validate_single_artifact(

--- a/manifests/task-100-fix-test-file-bypass-loophole.manifest.json
+++ b/manifests/task-100-fix-test-file-bypass-loophole.manifest.json
@@ -1,0 +1,29 @@
+{
+  "goal": "Fix security loophole where strict artifact validation is bypassed for files containing test_ prefixed functions by replacing function-name-based detection with path-based detection",
+  "description": "The _check_unexpected_artifacts function currently uses function-name-based detection (any func.startswith('test_')) which allows production code to hide in non-test files that happen to contain test_ prefixed functions. This fix replaces it with path-based detection using the proven pattern from file_tracker.py: file is in tests/ directory OR filename starts with test_",
+  "taskType": "edit",
+  "editableFiles": [
+    "maid_runner/validators/_artifact_validation.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/validators/file_tracker.py",
+    "maid_runner/validators/schemas/manifest.schema.json"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/_artifact_validation.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "_check_unexpected_artifacts",
+        "description": "Check for unexpected public artifacts in strict mode, using path-based test file detection",
+        "args": [
+          {"name": "expected_items", "type": "List[dict]"},
+          {"name": "collector", "type": "Any"},
+          {"name": "file_path", "type": "str"}
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_100_fix_test_file_bypass.py", "-v"]
+}

--- a/manifests/task-100a-manifest-validator-snapshot.manifest.json
+++ b/manifests/task-100a-manifest-validator-snapshot.manifest.json
@@ -1,0 +1,1031 @@
+{
+  "goal": "Comprehensive snapshot of manifest_validator.py with updated _check_unexpected_artifacts signature",
+  "description": "This manifest supersedes older manifests that declared _check_unexpected_artifacts with the old 2-parameter signature. It includes all current public functions with their updated signatures.",
+  "taskType": "snapshot",
+  "supersedes": [
+    "manifests/task-009-snapshot-manifest_validator.manifest.json",
+    "manifests/task-010-integrate-type-validation.manifest.json",
+    "manifests/task-015-fix-enum-import-detection.manifest.json",
+    "manifests/task-016-detect-abc-usage-patterns.manifest.json",
+    "manifests/task-023-fix-manifest-chain-artifact-filtering.manifest.json",
+    "manifests/task-024-fix-import-vs-definition-tracking.manifest.json",
+    "manifests/task-025-fix-cls-parameter-filtering.manifest.json",
+    "manifests/task-026-detect-classmethod-calls-on-class.manifest.json",
+    "manifests/task-027-validate-unexpected-methods.manifest.json",
+    "manifests/task-034-validate-all-editable-files.manifest.json",
+    "manifests/task-047-validator-system-manifest-support.manifest.json",
+    "manifests/task-048-validator-system-snapshot-handling.manifest.json",
+    "manifests/task-049-fix-async-function-detection.manifest.json",
+    "manifests/task-064-generic-base-class-support.manifest.json",
+    "manifests/task-065-fix-artifact-merge-key.manifest.json",
+    "manifests/task-076-typescript-artifact-type-validation.manifest.json",
+    "manifests/task-081-fix-method-parameter-validation.manifest.json",
+    "manifests/task-083-implement-absent-status-validation.manifest.json",
+    "manifests/task-087-update-validator-registry.manifest.json",
+    "manifests/task-092-filter-superseded-in-discover-related.manifest.json"
+  ],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/manifest_validator.py"
+  ],
+  "readonlyFiles": [],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/manifest_validator.py",
+    "contains": [
+      {
+        "type": "class",
+        "name": "AlignmentError",
+        "bases": [
+          "Exception"
+        ]
+      },
+      {
+        "type": "function",
+        "name": "validate_schema",
+        "args": [
+          {
+            "name": "manifest_data"
+          },
+          {
+            "name": "schema_path"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "extract_type_annotation",
+        "args": [
+          {
+            "name": "node",
+            "type": "ast.AST"
+          },
+          {
+            "name": "annotation_attr",
+            "type": "str"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "compare_types",
+        "args": [
+          {
+            "name": "manifest_type",
+            "type": "str"
+          },
+          {
+            "name": "implementation_type",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "normalize_type_string",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "discover_related_manifests",
+        "args": [
+          {
+            "name": "target_file",
+            "type": "str"
+          }
+        ],
+        "returns": "List[str]"
+      },
+      {
+        "type": "function",
+        "name": "validate_with_ast",
+        "args": [
+          {
+            "name": "manifest_data"
+          },
+          {
+            "name": "test_file_path"
+          },
+          {
+            "name": "use_manifest_chain"
+          },
+          {
+            "name": "validation_mode"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "collect_behavioral_artifacts",
+        "args": [
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "dict"
+      },
+      {
+        "type": "function",
+        "name": "validate_type_hints",
+        "args": [
+          {
+            "name": "manifest_artifacts",
+            "type": "dict"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "should_skip_behavioral_validation",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "Any"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "class",
+        "name": "_ArtifactCollector",
+        "bases": [
+          "ast.NodeVisitor"
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_is_system_manifest",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_validate_system_artifacts_structure",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_should_skip_behavioral_validation",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_should_skip_implementation_validation",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_extract_base_class_name",
+        "args": [
+          {
+            "name": "base",
+            "type": "ast.AST"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_ast_to_type_string",
+        "args": [
+          {
+            "name": "node",
+            "type": "Optional[ast.AST]"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_extraction_inputs",
+        "args": [
+          {
+            "name": "node",
+            "type": "Any"
+          },
+          {
+            "name": "annotation_attr",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_safe_ast_conversion",
+        "args": [
+          {
+            "name": "node",
+            "type": "ast.AST"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_handle_subscript_node",
+        "args": [
+          {
+            "name": "node",
+            "type": "ast.Subscript"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_handle_attribute_node",
+        "args": [
+          {
+            "name": "node",
+            "type": "ast.Attribute"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_handle_union_operator",
+        "args": [
+          {
+            "name": "node",
+            "type": "ast.BinOp"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_fallback_ast_unparse",
+        "args": [
+          {
+            "name": "node",
+            "type": "ast.AST"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_safe_str_conversion",
+        "args": [
+          {
+            "name": "node",
+            "type": "Any"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_type_input",
+        "args": [
+          {
+            "name": "type_value",
+            "type": "Any"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_modern_union_syntax",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_optional_type",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_is_optional_type",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_extract_bracketed_content",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          },
+          {
+            "name": "prefix",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_union_type",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_is_union_type",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_split_type_arguments",
+        "args": [
+          {
+            "name": "inner",
+            "type": "str"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_split_by_delimiter",
+        "args": [
+          {
+            "name": "text",
+            "type": "str"
+          },
+          {
+            "name": "delimiter",
+            "type": "str"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_normalize_comma_spacing",
+        "args": [
+          {
+            "name": "type_str",
+            "type": "str"
+          }
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "_skip_spaces",
+        "args": [
+          {
+            "name": "text",
+            "type": "str"
+          },
+          {
+            "name": "start_idx",
+            "type": "int"
+          }
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "_get_task_number",
+        "args": [
+          {
+            "name": "path"
+          }
+        ],
+        "returns": "int"
+      },
+      {
+        "type": "function",
+        "name": "_get_artifact_key",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          }
+        ],
+        "returns": "tuple"
+      },
+      {
+        "type": "function",
+        "name": "_merge_expected_artifacts",
+        "args": [
+          {
+            "name": "manifest_paths",
+            "type": "List[str]"
+          },
+          {
+            "name": "target_file",
+            "type": "str"
+          }
+        ],
+        "returns": "List[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_expected_artifacts",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          },
+          {
+            "name": "test_file_path",
+            "type": "str"
+          },
+          {
+            "name": "use_manifest_chain",
+            "type": "bool"
+          }
+        ],
+        "returns": "List[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_validator_for_file",
+        "args": [
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_parse_file",
+        "args": [
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "ast.AST"
+      },
+      {
+        "type": "function",
+        "name": "_collect_artifacts_from_ast",
+        "args": [
+          {
+            "name": "tree",
+            "type": "ast.AST"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "_ArtifactCollector"
+      },
+      {
+        "type": "function",
+        "name": "_validate_all_artifacts",
+        "args": [
+          {
+            "name": "expected_items",
+            "type": "List[dict]"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_check_unexpected_artifacts",
+        "args": [
+          {
+            "name": "expected_items",
+            "type": "List[dict]"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_single_artifact",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_artifact",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_behavioral",
+        "args": [
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_parameters_used",
+        "args": [
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_implementation",
+        "args": [
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_method_parameters",
+        "args": [
+          {
+            "name": "method_name",
+            "type": "str"
+          },
+          {
+            "name": "parameters",
+            "type": "List[dict]"
+          },
+          {
+            "name": "class_name",
+            "type": "str"
+          },
+          {
+            "name": "collector",
+            "type": "_ArtifactCollector"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_class",
+        "args": [
+          {
+            "name": "class_name"
+          },
+          {
+            "name": "expected_bases"
+          },
+          {
+            "name": "found_classes"
+          },
+          {
+            "name": "found_class_bases"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_validate_attribute",
+        "args": [
+          {
+            "name": "attribute_name"
+          },
+          {
+            "name": "parent_class"
+          },
+          {
+            "name": "found_attributes"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_validate_function",
+        "args": [
+          {
+            "name": "function_name"
+          },
+          {
+            "name": "expected_parameters"
+          },
+          {
+            "name": "found_functions"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_validate_no_unexpected_artifacts",
+        "args": [
+          {
+            "name": "expected_items"
+          },
+          {
+            "name": "found_classes"
+          },
+          {
+            "name": "found_functions"
+          },
+          {
+            "name": "found_methods"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "_is_typeddict_class",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_is_typeddict_base",
+        "args": [
+          {
+            "name": "base_name",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_should_skip_by_artifact_kind",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[bool]"
+      },
+      {
+        "type": "function",
+        "name": "_are_valid_type_validation_inputs",
+        "args": [
+          {
+            "name": "manifest_artifacts",
+            "type": "Any"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "Any"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_should_validate_artifact_types",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "Any"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_validate_function_types",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_get_implementation_info",
+        "args": [
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_method_info",
+        "args": [
+          {
+            "name": "method_name",
+            "type": "str"
+          },
+          {
+            "name": "class_name",
+            "type": "str"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_get_function_info",
+        "args": [
+          {
+            "name": "function_name",
+            "type": "str"
+          },
+          {
+            "name": "implementation_artifacts",
+            "type": "dict"
+          }
+        ],
+        "returns": "Optional[dict]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_parameter_types",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "impl_info",
+            "type": "dict"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "str"
+          }
+        ],
+        "returns": "list"
+      },
+      {
+        "type": "function",
+        "name": "_validate_single_parameter",
+        "args": [
+          {
+            "name": "param_name",
+            "type": "str"
+          },
+          {
+            "name": "manifest_type",
+            "type": "str"
+          },
+          {
+            "name": "impl_params_dict",
+            "type": "dict"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_return_type",
+        "args": [
+          {
+            "name": "artifact",
+            "type": "dict"
+          },
+          {
+            "name": "impl_info",
+            "type": "dict"
+          },
+          {
+            "name": "artifact_name",
+            "type": "str"
+          },
+          {
+            "name": "parent_class",
+            "type": "Optional[str]"
+          }
+        ],
+        "returns": "Optional[str]"
+      },
+      {
+        "type": "function",
+        "name": "_validate_absent_file",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          },
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_validate_file_status_semantic_rules",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          }
+        ],
+        "returns": "None"
+      },
+      {
+        "type": "function",
+        "name": "_has_undeclared_public_artifacts",
+        "args": [
+          {
+            "name": "file_path",
+            "type": "str"
+          }
+        ],
+        "returns": "bool"
+      },
+      {
+        "type": "function",
+        "name": "_validate_editable_files",
+        "args": [
+          {
+            "name": "manifest_data",
+            "type": "dict"
+          },
+          {
+            "name": "validation_mode",
+            "type": "str"
+          }
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": [
+    "echo",
+    "Snapshot manifest - no behavioral validation required"
+  ]
+}

--- a/tests/_test_task_009_private_helpers.py
+++ b/tests/_test_task_009_private_helpers.py
@@ -927,7 +927,7 @@ def _private_helper():
 
         expected_artifacts = [{"type": "function", "name": "public_function"}]
 
-        _check_unexpected_artifacts(expected_artifacts, collector)
+        _check_unexpected_artifacts(expected_artifacts, collector, str(impl_file))
 
 
 class TestValidateSingleArtifactBehavior:

--- a/tests/_test_task_027_private_helpers.py
+++ b/tests/_test_task_027_private_helpers.py
@@ -55,7 +55,7 @@ class Service:
 
         # Call _check_unexpected_artifacts directly - should raise error
         with pytest.raises(AlignmentError, match="unexpected_method"):
-            _check_unexpected_artifacts(expected_items, collector)
+            _check_unexpected_artifacts(expected_items, collector, str(test_file))
 
     def test_check_unexpected_artifacts_passes_when_all_declared(self, tmp_path):
         """Test that _check_unexpected_artifacts passes when all artifacts are declared."""
@@ -77,7 +77,7 @@ class Service:
         ]
 
         # Call _check_unexpected_artifacts directly - should not raise error
-        _check_unexpected_artifacts(expected_items, collector)
+        _check_unexpected_artifacts(expected_items, collector, str(test_file))
 
     def test_check_unexpected_artifacts_allows_private_methods(self, tmp_path):
         """Test that _check_unexpected_artifacts allows private methods."""
@@ -101,7 +101,7 @@ class Service:
         ]
 
         # Call _check_unexpected_artifacts directly - should not raise error for private methods
-        _check_unexpected_artifacts(expected_items, collector)
+        _check_unexpected_artifacts(expected_items, collector, str(test_file))
 
 
 class TestValidateNoUnexpectedArtifacts:

--- a/tests/test_task_100_fix_test_file_bypass.py
+++ b/tests/test_task_100_fix_test_file_bypass.py
@@ -1,0 +1,516 @@
+"""Behavioral tests for task-100: Fix Test File Bypass Loophole.
+
+These tests verify that _check_unexpected_artifacts uses path-based detection
+instead of function-name-based detection to determine if a file is a test file.
+
+The loophole: Previously, if ANY function in a file started with 'test_',
+strict validation would be skipped. This allowed production code to hide
+undeclared artifacts by having a test_helper() function in the file.
+
+The fix: Use path-based detection - a file is a test file if:
+  1. It's in a 'tests/' directory, OR
+  2. Its filename starts with 'test_'
+"""
+
+import pytest
+
+from maid_runner.validators._artifact_validation import _check_unexpected_artifacts
+from maid_runner.validators.manifest_validator import (
+    _ArtifactCollector,
+    _VALIDATION_MODE_IMPLEMENTATION,
+    AlignmentError,
+)
+
+
+class TestLoopholeClosure:
+    """Tests verifying the bypass loophole is closed."""
+
+    def test_catches_undeclared_in_non_test_file_with_test_prefix_function(
+        self, tmp_path
+    ):
+        """Production file with test_ prefixed function should NOT bypass validation.
+
+        This is the core loophole test. A file like src/utils.py with:
+          - test_helper() function (which previously caused bypass)
+          - public_api() function (undeclared)
+
+        Should raise AlignmentError for undeclared public_api.
+        """
+        # Create a production file with test_helper and public_api functions
+        prod_file = tmp_path / "src" / "utils.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def test_helper():
+    '''A helper with test_ prefix that should NOT cause bypass.'''
+    pass
+
+def public_api():
+    '''Undeclared public function that should be caught.'''
+    pass
+""")
+
+        # Collect artifacts from the file
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Expected artifacts only declare test_helper, not public_api
+        expected_items = [{"type": "function", "name": "test_helper"}]
+
+        # Call the function with file path - should raise for undeclared public_api
+        with pytest.raises(AlignmentError) as exc_info:
+            _check_unexpected_artifacts(
+                expected_items, collector, str(prod_file)
+            )
+
+        # Verify the error mentions the undeclared function
+        assert "public_api" in str(exc_info.value)
+        assert "Unexpected public function" in str(exc_info.value)
+
+    def test_catches_undeclared_class_in_non_test_file(self, tmp_path):
+        """Production file with undeclared class should raise error."""
+        # Create production file with undeclared class
+        prod_file = tmp_path / "src" / "models.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def test_data_factory():
+    '''Has test_ prefix but file is NOT a test file.'''
+    pass
+
+class UndeclaredModel:
+    '''This class is not declared in expected_items.'''
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Only declare the function, not the class
+        expected_items = [{"type": "function", "name": "test_data_factory"}]
+
+        # Should raise for undeclared class
+        with pytest.raises(AlignmentError) as exc_info:
+            _check_unexpected_artifacts(
+                expected_items, collector, str(prod_file)
+            )
+
+        assert "UndeclaredModel" in str(exc_info.value)
+        assert "Unexpected public class" in str(exc_info.value)
+
+
+class TestLegitimateTestFileSkipping:
+    """Tests verifying legitimate test files ARE skipped."""
+
+    def test_skips_validation_for_file_in_tests_directory(self, tmp_path):
+        """File in tests/ directory should skip strict validation."""
+        # Create a test file in tests/ directory
+        test_file = tmp_path / "tests" / "test_example.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("""
+def test_something():
+    pass
+
+def helper_function():
+    '''Not declared but should be allowed in test file.'''
+    pass
+
+class TestClass:
+    '''Not declared but should be allowed in test file.'''
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(test_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Only declare test_something - undeclared helper_function and TestClass
+        expected_items = [{"type": "function", "name": "test_something"}]
+
+        # Use a path that looks like tests/test_example.py
+        test_path = "tests/test_example.py"
+
+        # Should NOT raise - test file validation is skipped
+        _check_unexpected_artifacts(
+            expected_items, collector, test_path
+        )
+        # If we get here without exception, the test passes
+
+    def test_skips_validation_for_test_prefixed_filename(self, tmp_path):
+        """File with test_ prefix in filename should skip strict validation."""
+        # Create a test file with test_ prefix (not in tests/ dir)
+        test_file = tmp_path / "test_integration.py"
+        test_file.write_text("""
+def test_api():
+    pass
+
+def undeclared_helper():
+    '''Not declared but should be allowed.'''
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(test_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Only declare test_api
+        expected_items = [{"type": "function", "name": "test_api"}]
+
+        # Use path with test_ prefix in filename
+        test_path = "test_integration.py"
+
+        # Should NOT raise - test file validation is skipped
+        _check_unexpected_artifacts(
+            expected_items, collector, test_path
+        )
+
+    def test_skips_validation_for_nested_tests_directory(self, tmp_path):
+        """File in nested tests/ directory should skip validation."""
+        # Create file in nested tests directory
+        test_file = tmp_path / "tests" / "unit" / "test_module.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("""
+def test_unit():
+    pass
+
+def fixture_helper():
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(test_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        expected_items = [{"type": "function", "name": "test_unit"}]
+
+        # Path starts with tests/
+        test_path = "tests/unit/test_module.py"
+
+        # Should NOT raise
+        _check_unexpected_artifacts(
+            expected_items, collector, test_path
+        )
+
+
+class TestEdgeCases:
+    """Tests for edge cases in path-based detection."""
+
+    def test_testing_utils_file_is_not_test_file(self, tmp_path):
+        """File named testing_utils.py is NOT a test file (no test_ prefix)."""
+        # Create a utility file that contains 'test' but doesn't start with 'test_'
+        util_file = tmp_path / "src" / "testing_utils.py"
+        util_file.parent.mkdir(parents=True)
+        util_file.write_text("""
+def create_test_data():
+    '''Function to create test data.'''
+    pass
+
+def undeclared_function():
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(util_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        expected_items = [{"type": "function", "name": "create_test_data"}]
+
+        # Path does NOT start with test_ in filename
+        file_path = "src/testing_utils.py"
+
+        # Should raise - this is NOT a test file
+        with pytest.raises(AlignmentError) as exc_info:
+            _check_unexpected_artifacts(
+                expected_items, collector, file_path
+            )
+
+        assert "undeclared_function" in str(exc_info.value)
+
+    def test_my_test_file_is_not_test_file(self, tmp_path):
+        """File named my_test.py is NOT a test file (improper naming)."""
+        # Create file with improper test naming
+        file = tmp_path / "src" / "my_test.py"
+        file.parent.mkdir(parents=True)
+        file.write_text("""
+def run_tests():
+    pass
+
+def undeclared():
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        expected_items = [{"type": "function", "name": "run_tests"}]
+
+        # Filename is my_test.py, not test_my.py
+        file_path = "src/my_test.py"
+
+        # Should raise - this is NOT a test file
+        with pytest.raises(AlignmentError) as exc_info:
+            _check_unexpected_artifacts(
+                expected_items, collector, file_path
+            )
+
+        assert "undeclared" in str(exc_info.value)
+
+    def test_tests_directory_non_test_filename(self, tmp_path):
+        """File in tests/ dir but NOT named test_*.py should still be skipped.
+
+        Directory takes precedence - if in tests/ directory, skip validation.
+        This covers conftest.py, fixtures.py, etc.
+        """
+        # Create a helper file in tests/ directory
+        helper_file = tmp_path / "tests" / "conftest.py"
+        helper_file.parent.mkdir(parents=True)
+        helper_file.write_text("""
+import pytest
+
+@pytest.fixture
+def sample_fixture():
+    pass
+
+def helper():
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(helper_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        expected_items = [{"type": "function", "name": "sample_fixture"}]
+
+        # In tests/ directory
+        file_path = "tests/conftest.py"
+
+        # Should NOT raise - file is in tests/ directory
+        _check_unexpected_artifacts(
+            expected_items, collector, file_path
+        )
+
+    def test_private_functions_not_caught(self, tmp_path):
+        """Private functions (starting with _) should not be flagged."""
+        prod_file = tmp_path / "src" / "module.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def public_api():
+    pass
+
+def _private_helper():
+    '''Private function should not trigger error.'''
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Declare public_api, don't declare _private_helper
+        expected_items = [{"type": "function", "name": "public_api"}]
+
+        file_path = "src/module.py"
+
+        # Should NOT raise - _private_helper is private
+        _check_unexpected_artifacts(
+            expected_items, collector, file_path
+        )
+
+
+class TestNonTestFileWithNoTestFunctions:
+    """Tests verifying normal non-test files work correctly."""
+
+    def test_normal_file_catches_undeclared_artifacts(self, tmp_path):
+        """Normal production file should catch undeclared artifacts."""
+        prod_file = tmp_path / "src" / "service.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def get_user():
+    pass
+
+def delete_user():
+    pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Only declare get_user
+        expected_items = [{"type": "function", "name": "get_user"}]
+
+        file_path = "src/service.py"
+
+        # Should raise for undeclared delete_user
+        with pytest.raises(AlignmentError) as exc_info:
+            _check_unexpected_artifacts(
+                expected_items, collector, file_path
+            )
+
+        assert "delete_user" in str(exc_info.value)
+
+    def test_all_declared_artifacts_pass(self, tmp_path):
+        """When all artifacts are declared, no error should be raised."""
+        prod_file = tmp_path / "src" / "complete.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def func_a():
+    pass
+
+def func_b():
+    pass
+
+class MyClass:
+    def method(self):
+        pass
+""")
+
+        # Collect artifacts
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Declare all public artifacts
+        expected_items = [
+            {"type": "function", "name": "func_a"},
+            {"type": "function", "name": "func_b"},
+            {"type": "class", "name": "MyClass"},
+            {"type": "function", "name": "method", "class": "MyClass"},
+        ]
+
+        file_path = "src/complete.py"
+
+        # Should NOT raise - all artifacts declared
+        _check_unexpected_artifacts(
+            expected_items, collector, file_path
+        )
+
+
+class TestPathNormalization:
+    """Tests for different path formats."""
+
+    def test_handles_forward_slashes(self, tmp_path):
+        """Paths with forward slashes should work correctly."""
+        prod_file = tmp_path / "deep" / "nested" / "module.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def declared_func():
+    pass
+
+def test_like_name():
+    '''Has test_ prefix but file path is NOT a test path.'''
+    pass
+
+def undeclared():
+    pass
+""")
+
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        expected_items = [
+            {"type": "function", "name": "declared_func"},
+            {"type": "function", "name": "test_like_name"},
+        ]
+
+        # Forward slash path
+        file_path = "deep/nested/module.py"
+
+        with pytest.raises(AlignmentError) as exc_info:
+            _check_unexpected_artifacts(
+                expected_items, collector, file_path
+            )
+
+        assert "undeclared" in str(exc_info.value)
+
+    def test_handles_tests_path_with_subdirectory(self, tmp_path):
+        """tests/ path with subdirectories should be recognized."""
+        test_file = tmp_path / "tests" / "integration" / "api" / "test_endpoints.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("""
+def test_get_endpoint():
+    pass
+
+def undeclared_helper():
+    pass
+""")
+
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(test_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        expected_items = [{"type": "function", "name": "test_get_endpoint"}]
+
+        # Deeply nested in tests/
+        file_path = "tests/integration/api/test_endpoints.py"
+
+        # Should NOT raise - in tests/ directory
+        _check_unexpected_artifacts(
+            expected_items, collector, file_path
+        )
+
+
+class TestEmptyExpectedItems:
+    """Tests for behavior when expected_items is empty."""
+
+    def test_empty_expected_items_skips_validation(self, tmp_path):
+        """When expected_items is empty, no validation occurs."""
+        prod_file = tmp_path / "src" / "empty_manifest.py"
+        prod_file.parent.mkdir(parents=True)
+        prod_file.write_text("""
+def some_function():
+    pass
+""")
+
+        collector = _ArtifactCollector(validation_mode=_VALIDATION_MODE_IMPLEMENTATION)
+        import ast
+        with open(prod_file, "r") as f:
+            tree = ast.parse(f.read())
+        collector.visit(tree)
+
+        # Empty expected_items
+        expected_items = []
+
+        file_path = "src/empty_manifest.py"
+
+        # Should NOT raise - empty expected_items skips strict validation
+        _check_unexpected_artifacts(
+            expected_items, collector, file_path
+        )

--- a/tests/validators/test_ast_validator_strict.py
+++ b/tests/validators/test_ast_validator_strict.py
@@ -258,8 +258,8 @@ def unexpected_function():
         validate_with_ast(manifest, str(test_file))
 
 
-def test_file_with_test_prefix_but_no_test_functions(tmp_path: Path):
-    """Test edge case: filename starts with test but no test functions."""
+def test_file_with_test_prefix_skips_strict_validation(tmp_path: Path):
+    """Test that file with test_ prefix in name skips strict validation (path-based detection)."""
     code = """
 def setup():
     pass
@@ -268,7 +268,7 @@ def teardown():
     pass
 
 def helper_function():
-    # File named test_*.py but no test_ functions
+    # File named test_*.py should skip strict validation
     pass
 """
     test_file = tmp_path / "test_helpers.py"
@@ -279,10 +279,9 @@ def helper_function():
             "contains": [
                 {"type": "function", "name": "setup"},
                 {"type": "function", "name": "teardown"},
-                # helper_function not listed
+                # helper_function not listed but OK since test file
             ]
         }
     }
-    # Should fail - no test_ functions means strict validation applies
-    with pytest.raises(AlignmentError, match="Unexpected public function"):
-        validate_with_ast(manifest, str(test_file))
+    # Should pass - file with test_ prefix is a test file, skips strict validation
+    validate_with_ast(manifest, str(test_file))

--- a/tests/validators/test_manifest_merger.py
+++ b/tests/validators/test_manifest_merger.py
@@ -50,12 +50,14 @@ def testdiscover_related_manifests():
         task_numbers
     ), f"Manifests not in chronological order: {task_numbers}"
 
-    # Verify that task-009 (which superseded task-001, 002, 003) is included
-    # but the superseded tasks are NOT included
-    found_task_009 = any("task-009" in name for name in manifest_names)
+    # Verify that the current snapshot (task-100a which superseded task-009)
+    # or task-009 is included, but older superseded tasks are NOT
+    found_current_snapshot = any(
+        "task-100a" in name or "task-009" in name for name in manifest_names
+    )
     assert (
-        found_task_009
-    ), f"Expected to find task-009 (snapshot), found: {manifest_names}"
+        found_current_snapshot
+    ), f"Expected to find task-100a or task-009 (snapshot), found: {manifest_names}"
 
     # Verify that superseded tasks are NOT included
     superseded_tasks = ["task-001", "task-002", "task-003"]


### PR DESCRIPTION
Replace function-name-based test file detection with path-based detection to prevent production code from bypassing strict artifact validation.

The previous approach checked if any function started with "test_", which allowed production files to escape validation by including helper functions like test_helper(). Now detection uses file path:
- Files in tests/ directory are test files
- Files with names starting with test_ are test files

Changes:
- Add _is_test_file_path() helper function
- Update _check_unexpected_artifacts() to accept file_path parameter
- Update all callers to pass file_path context

Closes #100