### PR TITLE
fix: close test file bypass security loophole (issue #100)

### DIFF
--- a/maid_runner/validators/_artifact_validation.py
+++ b/maid_runner/validators/_artifact_validation.py
@@ -77,9 +77,15 @@ def _is_test_file_path(file_path: str) -> bool:
     """
     if not file_path:
         return False
-    # Normalize path separators
+    # Normalize path separators (Windows backslashes to forward slashes)
     normalized = file_path.replace("\\", "/")
-    # Check if in tests directory
+    # Strip leading ./ for relative paths
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    # Check if in tests directory (handles relative, absolute, and various formats)
+    # - "tests/..." (relative)
+    # - "/path/to/tests/..." (absolute)
+    # - "./tests/..." (explicit relative, after stripping)
     if normalized.startswith("tests/") or "/tests/" in normalized:
         return True
     # Check if filename starts with test_

--- a/maid_runner/validators/manifest_validator.py
+++ b/maid_runner/validators/manifest_validator.py
@@ -275,7 +275,7 @@ def validate_with_ast(
 
     # Convert to collector-like object for compatibility
     class _CollectorShim:
-        def __init__(self, artifacts_dict):
+        def __init__(self, artifacts_dict, file_path: str = ""):
             self.found_classes = artifacts_dict.get("found_classes", set())
             self.found_class_bases = artifacts_dict.get("found_class_bases", {})
             self.found_attributes = artifacts_dict.get("found_attributes", {})
@@ -288,8 +288,10 @@ def validate_with_ast(
             self.used_functions = artifacts_dict.get("used_functions", set())
             self.used_methods = artifacts_dict.get("used_methods", {})
             self.used_arguments = artifacts_dict.get("used_arguments", set())
+            # Store file path for path-based test file detection (security fix)
+            self.file_path = file_path
 
-    collector = _CollectorShim(artifacts)
+    collector = _CollectorShim(artifacts, test_file_path)
 
     # Get expected artifacts
     expected_items = _get_expected_artifacts(


### PR DESCRIPTION

Replace function-name-based test file detection with path-based detection
to prevent production code from bypassing strict artifact validation.

The previous approach checked if any function started with "test_", which
allowed production files to escape validation by including helper functions
like test_helper(). Now detection uses file path:
- Files in tests/ directory are test files
- Files with names starting with test_ are test files

Implementation approach (MAID-compliant, no manifest supersession):
- Add file_path attribute to internal _CollectorShim class
- Add _is_test_file_path() helper for path-based detection
- Use getattr() to safely access collector.file_path

Closes #100