### PR TITLE
fix: address PR #110 review feedback for Knowledge Graph module

### DIFF
--- a/maid_runner/graph/__init__.py
+++ b/maid_runner/graph/__init__.py
@@ -14,6 +14,11 @@ from maid_runner.graph.model import (
     EdgeType,
     Edge,
     KnowledgeGraph,
+    MANIFEST_PREFIX,
+    FILE_PREFIX,
+    ARTIFACT_PREFIX,
+    MODULE_PREFIX,
+    EDGE_PREFIX,
 )
 from maid_runner.graph.exporters import (
     export_json,
@@ -74,6 +79,11 @@ __all__ = [
     "EdgeType",
     "Edge",
     "KnowledgeGraph",
+    "MANIFEST_PREFIX",
+    "FILE_PREFIX",
+    "ARTIFACT_PREFIX",
+    "MODULE_PREFIX",
+    "EDGE_PREFIX",
     "export_json",
     "export_dot",
     "export_graphml",

--- a/manifests/task-105-node-factory.manifest.json
+++ b/manifests/task-105-node-factory.manifest.json
@@ -20,9 +20,10 @@
       {
         "type": "function",
         "name": "create_file_node",
-        "description": "Create a FileNode from a file path string",
+        "description": "Create a FileNode from a file path string with optional status",
         "args": [
-          {"name": "file_path", "type": "str"}
+          {"name": "file_path", "type": "str"},
+          {"name": "status", "type": "str"}
         ],
         "returns": "FileNode"
       },

--- a/manifests/task-106-edge-factory.manifest.json
+++ b/manifests/task-106-edge-factory.manifest.json
@@ -10,10 +10,11 @@
       {
         "type": "function",
         "name": "create_supersedes_edges",
-        "description": "Create SUPERSEDES edges from a manifest to each superseded manifest",
+        "description": "Create SUPERSEDES edges from a manifest to each superseded manifest, with optional validation",
         "args": [
           {"name": "manifest_data", "type": "Dict[str, Any]"},
-          {"name": "manifest_node", "type": "ManifestNode"}
+          {"name": "manifest_node", "type": "ManifestNode"},
+          {"name": "known_manifest_ids", "type": "Optional[set]"}
         ],
         "returns": "List[Edge]"
       },

--- a/manifests/task-107-knowledge-graph-builder.manifest.json
+++ b/manifests/task-107-knowledge-graph-builder.manifest.json
@@ -34,10 +34,11 @@
         "type": "function",
         "name": "_process_manifest",
         "class": "KnowledgeGraphBuilder",
-        "description": "Process a single manifest, creating nodes and edges",
+        "description": "Process a single manifest, creating nodes and edges with optional validation",
         "args": [
           {"name": "manifest_data", "type": "Dict[str, Any]"},
-          {"name": "path", "type": "Path"}
+          {"name": "path", "type": "Path"},
+          {"name": "known_manifest_ids", "type": "Optional[set]"}
         ],
         "returns": "None"
       },

--- a/tests/test_task_107_knowledge_graph_builder.py
+++ b/tests/test_task_107_knowledge_graph_builder.py
@@ -269,9 +269,21 @@ class TestKnowledgeGraphBuilderBuild:
         assert len(artifact_nodes) >= 2
 
     def test_build_creates_supersedes_edges(
-        self, manifest_dir: Path, manifest_with_supersedes: Dict[str, Any]
+        self,
+        manifest_dir: Path,
+        sample_manifest_data: Dict[str, Any],
+        manifest_with_supersedes: Dict[str, Any],
     ) -> None:
         """build() creates SUPERSEDES edges for supersedes relationships."""
+        # Create the superseded manifest first so the edge can be validated
+        create_manifest_file(
+            manifest_dir, "task-001.manifest.json", sample_manifest_data
+        )
+        # Update supersedes path to match the actual manifest location
+        manifest_with_supersedes = manifest_with_supersedes.copy()
+        manifest_with_supersedes["supersedes"] = [
+            str(manifest_dir / "task-001.manifest.json")
+        ]
         create_manifest_file(
             manifest_dir, "task-002.manifest.json", manifest_with_supersedes
         )


### PR DESCRIPTION
Performance:
- Add adjacency list indexing in KnowledgeGraph for O(1) edge lookups
  instead of O(n) scanning (critical performance fix)

Code Quality:
- Remove redundant @dataclass decorators from Node, Edge, and Query
  classes that already have manual __init__ implementations
- Extract magic string constants for node ID prefixes (MANIFEST_PREFIX,
  FILE_PREFIX, ARTIFACT_PREFIX, MODULE_PREFIX, EDGE_PREFIX)

Bug Fixes:
- Add validation for supersedes edges to prevent dangling references
  to non-existent manifests
- Fix cycle detection to properly normalize cycles and detect duplicates
  with different starting points (e.g., [A,B,C] vs [B,C,A])
- Fix FileNode status to reflect actual file category (creatable,
  editable, readonly) instead of always "unknown"

Manifest Updates:
- Update task-105, task-106, task-107 manifests to include new optional
  parameters (status, known_manifest_ids)
- Update test to properly create superseded manifests for validation