### PR TITLE
feat: add --json-output flag for LSP integration

### DIFF
--- a/maid_runner/cli/list_manifests.py
+++ b/maid_runner/cli/list_manifests.py
@@ -88,8 +88,9 @@ def format_manifests_json(categorized_manifests: dict, manifest_dir: str) -> str
     manifest_dir_path = Path(manifest_dir)
     for category in ["created", "edited", "read"]:
         for manifest_name in categorized_manifests.get(category, []):
-            # Construct full path using Path for cross-platform compatibility
-            full_path = str(manifest_dir_path / manifest_name)
+            # Construct full path using Path, then convert to POSIX format
+            # for cross-platform JSON compatibility (LSP expects forward slashes)
+            full_path = (manifest_dir_path / manifest_name).as_posix()
             all_manifests.add(full_path)
 
     # Return as JSON array

--- a/maid_runner/cli/list_manifests.py
+++ b/maid_runner/cli/list_manifests.py
@@ -85,10 +85,11 @@ def format_manifests_json(categorized_manifests: dict, manifest_dir: str) -> str
     """
     # Collect all manifests from all categories
     all_manifests = set()
+    manifest_dir_path = Path(manifest_dir)
     for category in ["created", "edited", "read"]:
         for manifest_name in categorized_manifests.get(category, []):
-            # Construct full path: manifest_dir + manifest_name
-            full_path = f"{manifest_dir}/{manifest_name}"
+            # Construct full path using Path for cross-platform compatibility
+            full_path = str(manifest_dir_path / manifest_name)
             all_manifests.add(full_path)
 
     # Return as JSON array

--- a/maid_runner/cli/main.py
+++ b/maid_runner/cli/main.py
@@ -276,6 +276,12 @@ def main():
         help="Enable manifest chain caching for improved performance",
     )
 
+    validate_parser.add_argument(
+        "--json-output",
+        action="store_true",
+        help="Output validation results as JSON (for tool integration)",
+    )
+
     # Add coherence validation arguments
     add_coherence_arguments(validate_parser)
 
@@ -403,6 +409,11 @@ mixed test runners (pytest + vitest, etc.).""",
         "-q",
         action="store_true",
         help="Show minimal output (just manifest names)",
+    )
+    list_manifests_parser.add_argument(
+        "--json-output",
+        action="store_true",
+        help="Output manifest list as JSON array",
     )
 
     # Init subcommand
@@ -620,6 +631,7 @@ Automatically handles:
             verbose=args.verbose,
             skip_tests=args.skip_tests,
             use_cache=args.use_cache,
+            json_output=args.json_output,
         )
 
         # Run coherence validation if requested (after standard validation)
@@ -653,7 +665,9 @@ Automatically handles:
     elif args.command == "manifests":
         from maid_runner.cli.list_manifests import run_list_manifests
 
-        run_list_manifests(args.file_path, args.manifest_dir, args.quiet)
+        run_list_manifests(
+            args.file_path, args.manifest_dir, args.quiet, args.json_output
+        )
     elif args.command == "init":
         from maid_runner.cli.init import run_init
 

--- a/maid_runner/cli/validate.py
+++ b/maid_runner/cli/validate.py
@@ -1646,7 +1646,9 @@ def _run_validation_with_json_output(
                     ValidationError(
                         code=ErrorCode.ARTIFACT_NOT_FOUND,
                         message=str(e),
-                        file=file_path,
+                        file=getattr(e, "file", None) or file_path,
+                        line=getattr(e, "line", None),
+                        column=getattr(e, "column", None),
                         severity=ErrorSeverity.ERROR,
                     )
                 )
@@ -1668,7 +1670,9 @@ def _run_validation_with_json_output(
                     ValidationError(
                         code=ErrorCode.ARTIFACT_NOT_FOUND,
                         message=str(e),
-                        file=file_path,
+                        file=getattr(e, "file", None) or file_path,
+                        line=getattr(e, "line", None),
+                        column=getattr(e, "column", None),
                         severity=ErrorSeverity.ERROR,
                     )
                 )

--- a/maid_runner/validation_result.py
+++ b/maid_runner/validation_result.py
@@ -1,0 +1,97 @@
+"""Validation result types for structured validation output.
+
+Provides LSP-compatible data structures for validation results,
+supporting the --json-output flag in CLI commands.
+"""
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ErrorSeverity(Enum):
+    """Enum for validation error severity levels."""
+
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass
+class ValidationError:
+    """Dataclass representing a single validation error with location info."""
+
+    code: str
+    message: str
+    file: Optional[str] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    severity: ErrorSeverity = ErrorSeverity.ERROR
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert error to dictionary for JSON serialization.
+
+        Returns:
+            Dictionary with code, message, severity (always),
+            and file, line, column (only if set).
+        """
+        result: Dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "severity": self.severity.value,
+        }
+
+        if self.file is not None:
+            result["file"] = self.file
+        if self.line is not None:
+            result["line"] = self.line
+        if self.column is not None:
+            result["column"] = self.column
+
+        return result
+
+
+@dataclass
+class ValidationResult:
+    """Dataclass representing complete validation result with errors and metadata."""
+
+    success: bool = True
+    errors: List[ValidationError] = field(default_factory=list)
+    warnings: List[ValidationError] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def add_error(self, error: ValidationError) -> None:
+        """Add error to result, sets success=False if severity is ERROR.
+
+        Args:
+            error: The validation error to add.
+        """
+        if error.severity == ErrorSeverity.ERROR:
+            self.errors.append(error)
+            self.success = False
+        else:
+            self.warnings.append(error)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert result to maid-lsp compatible dictionary.
+
+        Returns:
+            Dictionary with success, errors, warnings, and metadata.
+        """
+        return {
+            "success": self.success,
+            "errors": [e.to_dict() for e in self.errors],
+            "warnings": [w.to_dict() for w in self.warnings],
+            "metadata": self.metadata,
+        }
+
+    def to_json(self, indent: Optional[int] = None) -> str:
+        """Convert result to JSON string.
+
+        Args:
+            indent: Optional indentation level for pretty-printing.
+
+        Returns:
+            JSON string representation of the validation result.
+        """
+        return json.dumps(self.to_dict(), indent=indent)

--- a/maid_runner/validation_result.py
+++ b/maid_runner/validation_result.py
@@ -2,12 +2,54 @@
 
 Provides LSP-compatible data structures for validation results,
 supporting the --json-output flag in CLI commands.
+
+Error Code Reference:
+    E0XX - File/JSON errors:
+        E001: File not found or invalid JSON
+        E002: JSON schema validation failed
+
+    E1XX - Semantic validation errors:
+        E101: MAID semantic validation failed (e.g., multi-file artifacts)
+        E102: Supersession validation failed
+
+    E3XX - Implementation validation errors:
+        E301: Expected artifact not found in implementation
+        E308: Alignment error during validation
+
+    E9XX - System errors:
+        E999: Unexpected/unhandled error
 """
 
 import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
+
+
+class ErrorCode:
+    """Standard error codes for MAID validation.
+
+    Groups:
+        E0XX: File and JSON parsing errors
+        E1XX: Semantic validation errors
+        E3XX: Implementation validation errors
+        E9XX: System/unexpected errors
+    """
+
+    # File/JSON errors (E0XX)
+    FILE_NOT_FOUND = "E001"
+    SCHEMA_VALIDATION_FAILED = "E002"
+
+    # Semantic validation errors (E1XX)
+    SEMANTIC_VALIDATION_FAILED = "E101"
+    SUPERSESSION_VALIDATION_FAILED = "E102"
+
+    # Implementation validation errors (E3XX)
+    ARTIFACT_NOT_FOUND = "E301"
+    ALIGNMENT_ERROR = "E308"
+
+    # System errors (E9XX)
+    UNEXPECTED_ERROR = "E999"
 
 
 class ErrorSeverity(Enum):

--- a/maid_runner/validators/manifest_validator.py
+++ b/maid_runner/validators/manifest_validator.py
@@ -77,9 +77,26 @@ _NONE_TYPE = _NONE_TYPE_IMPL
 
 
 class AlignmentError(Exception):
-    """Raised when expected artifacts are not found in the code."""
+    """Raised when expected artifacts are not found in the code.
 
-    pass
+    Attributes:
+        message: Error description.
+        file: Optional file path where the error occurred.
+        line: Optional line number (1-based) where the error occurred.
+        column: Optional column number (1-based) where the error occurred.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        file: Optional[str] = None,
+        line: Optional[int] = None,
+        column: Optional[int] = None,
+    ):
+        super().__init__(message)
+        self.file = file
+        self.line = line
+        self.column = column
 
 
 def validate_schema(manifest_data, schema_path):

--- a/manifests/task-142-validation-result-types.manifest.json
+++ b/manifests/task-142-validation-result-types.manifest.json
@@ -1,0 +1,130 @@
+{
+  "version": "1",
+  "goal": "Create core data structures for structured validation output to support --json-output flag in CLI commands",
+  "description": "Add ValidationResult and ValidationError dataclasses with ErrorSeverity enum for LSP-compatible JSON output. The maid-lsp server expects structured output with success status, errors array, warnings array, and metadata.",
+  "taskType": "create",
+  "creatableFiles": [
+    "maid_runner/validation_result.py"
+  ],
+  "readonlyFiles": [
+    "tests/test_task_142_validation_result.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validation_result.py",
+    "contains": [
+      {
+        "type": "class",
+        "name": "ErrorSeverity",
+        "bases": ["Enum"],
+        "description": "Enum for validation error severity levels"
+      },
+      {
+        "type": "attribute",
+        "name": "ERROR",
+        "class": "ErrorSeverity"
+      },
+      {
+        "type": "attribute",
+        "name": "WARNING",
+        "class": "ErrorSeverity"
+      },
+      {
+        "type": "class",
+        "name": "ValidationError",
+        "description": "Dataclass representing a single validation error with location info"
+      },
+      {
+        "type": "attribute",
+        "name": "code",
+        "class": "ValidationError"
+      },
+      {
+        "type": "attribute",
+        "name": "message",
+        "class": "ValidationError"
+      },
+      {
+        "type": "attribute",
+        "name": "file",
+        "class": "ValidationError"
+      },
+      {
+        "type": "attribute",
+        "name": "line",
+        "class": "ValidationError"
+      },
+      {
+        "type": "attribute",
+        "name": "column",
+        "class": "ValidationError"
+      },
+      {
+        "type": "attribute",
+        "name": "severity",
+        "class": "ValidationError"
+      },
+      {
+        "type": "function",
+        "name": "to_dict",
+        "class": "ValidationError",
+        "args": [],
+        "returns": "Dict[str, Any]",
+        "description": "Convert error to dictionary for JSON serialization"
+      },
+      {
+        "type": "class",
+        "name": "ValidationResult",
+        "description": "Dataclass representing complete validation result with errors and metadata"
+      },
+      {
+        "type": "attribute",
+        "name": "success",
+        "class": "ValidationResult"
+      },
+      {
+        "type": "attribute",
+        "name": "errors",
+        "class": "ValidationResult"
+      },
+      {
+        "type": "attribute",
+        "name": "warnings",
+        "class": "ValidationResult"
+      },
+      {
+        "type": "attribute",
+        "name": "metadata",
+        "class": "ValidationResult"
+      },
+      {
+        "type": "function",
+        "name": "add_error",
+        "class": "ValidationResult",
+        "args": [
+          {"name": "error", "type": "ValidationError"}
+        ],
+        "returns": "None",
+        "description": "Add error to result, sets success=False if severity is ERROR"
+      },
+      {
+        "type": "function",
+        "name": "to_dict",
+        "class": "ValidationResult",
+        "args": [],
+        "returns": "Dict[str, Any]",
+        "description": "Convert result to maid-lsp compatible dictionary"
+      },
+      {
+        "type": "function",
+        "name": "to_json",
+        "class": "ValidationResult",
+        "args": [
+          {"name": "indent", "type": "Optional[int]", "default": "None"}
+        ],
+        "returns": "str",
+        "description": "Convert result to JSON string"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_142_validation_result.py", "-v"]
+}

--- a/manifests/task-142-validation-result-types.manifest.json
+++ b/manifests/task-142-validation-result-types.manifest.json
@@ -14,6 +14,46 @@
     "contains": [
       {
         "type": "class",
+        "name": "ErrorCode",
+        "description": "Standard error codes for MAID validation"
+      },
+      {
+        "type": "attribute",
+        "name": "FILE_NOT_FOUND",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "attribute",
+        "name": "SCHEMA_VALIDATION_FAILED",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "attribute",
+        "name": "SEMANTIC_VALIDATION_FAILED",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "attribute",
+        "name": "SUPERSESSION_VALIDATION_FAILED",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "attribute",
+        "name": "ARTIFACT_NOT_FOUND",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "attribute",
+        "name": "ALIGNMENT_ERROR",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "attribute",
+        "name": "UNEXPECTED_ERROR",
+        "class": "ErrorCode"
+      },
+      {
+        "type": "class",
         "name": "ErrorSeverity",
         "bases": ["Enum"],
         "description": "Enum for validation error severity levels"

--- a/manifests/task-143-list-manifests-json-output.manifest.json
+++ b/manifests/task-143-list-manifests-json-output.manifest.json
@@ -1,0 +1,38 @@
+{
+  "goal": "Add --json-output flag to maid manifests command that outputs a JSON array of manifest paths instead of formatted text",
+  "description": "The maid-lsp server needs to call `maid manifests <file> --json-output` and receive a JSON array of manifest paths. This manifest covers the list_manifests.py changes: adding format_manifests_json() function and modifying run_list_manifests() to accept json_output parameter.",
+  "taskType": "edit",
+  "editableFiles": [
+    "maid_runner/cli/list_manifests.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/cli/main.py",
+    "maid_runner/utils/__init__.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/list_manifests.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "format_manifests_json",
+        "args": [
+          {"name": "categorized_manifests", "type": "dict"},
+          {"name": "manifest_dir", "type": "str"}
+        ],
+        "returns": "str"
+      },
+      {
+        "type": "function",
+        "name": "run_list_manifests",
+        "args": [
+          {"name": "file_path", "type": "str"},
+          {"name": "manifest_dir", "type": "str"},
+          {"name": "quiet", "type": "bool"},
+          {"name": "json_output", "type": "bool"}
+        ],
+        "returns": "None"
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/test_task_143_list_manifests_json_output.py", "-v"]
+}

--- a/manifests/task-144-add-json-output-flag-to-maid-validate-command-for.manifest.json
+++ b/manifests/task-144-add-json-output-flag-to-maid-validate-command-for.manifest.json
@@ -1,0 +1,59 @@
+{
+  "version": "1",
+  "goal": "Add --json-output flag to maid validate command for structured JSON output using ValidationResult types",
+  "description": "Add format_validation_json() function to validate.py that formats validation results as JSON using ValidationResult types from task-142. The main.py CLI wiring changes (adding --json-output argument) are implementation details handled during Phase 3. The JSON output format is compatible with maid-lsp expectations.",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/cli/validate.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/validation_result.py",
+    "maid_runner/cli/main.py",
+    "tests/test_task_144_json_output.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/validate.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "format_validation_json",
+        "args": [
+          {"name": "success", "type": "bool"},
+          {"name": "errors", "type": "List[ValidationError]"},
+          {"name": "warnings", "type": "List[ValidationError]"},
+          {"name": "metadata", "type": "Dict[str, Any]"}
+        ],
+        "returns": "str",
+        "description": "Format validation results as JSON string in maid-lsp compatible format"
+      },
+      {
+        "type": "function",
+        "name": "run_validation",
+        "args": [
+          {"name": "manifest_path", "type": "Optional[str]"},
+          {"name": "validation_mode", "type": "str"},
+          {"name": "use_manifest_chain", "type": "bool"},
+          {"name": "quiet", "type": "bool"},
+          {"name": "manifest_dir", "type": "Optional[str]"},
+          {"name": "skip_file_tracking", "type": "bool"},
+          {"name": "watch", "type": "bool"},
+          {"name": "watch_all", "type": "bool"},
+          {"name": "timeout", "type": "int"},
+          {"name": "verbose", "type": "bool"},
+          {"name": "skip_tests", "type": "bool"},
+          {"name": "use_cache", "type": "bool"},
+          {"name": "json_output", "type": "bool"}
+        ],
+        "returns": "None",
+        "description": "Core validation logic with json_output parameter for structured JSON output"
+      }
+    ]
+  },
+  "validationCommand": [
+    "pytest",
+    "tests/test_task_144_json_output.py",
+    "-v"
+  ]
+}

--- a/tests/test_task_142_validation_result.py
+++ b/tests/test_task_142_validation_result.py
@@ -1,0 +1,415 @@
+"""Behavioral tests for validation result types (Task-142).
+
+Tests the ErrorSeverity enum, ValidationError dataclass, and ValidationResult dataclass
+that provide structured validation output for maid-lsp compatibility.
+"""
+
+import json
+
+from maid_runner.validation_result import (
+    ErrorSeverity,
+    ValidationError,
+    ValidationResult,
+)
+
+
+class TestErrorSeverity:
+    """Tests for ErrorSeverity enum."""
+
+    def test_error_severity_has_error_value(self) -> None:
+        """ErrorSeverity enum has ERROR member."""
+        assert hasattr(ErrorSeverity, "ERROR")
+        assert ErrorSeverity.ERROR is not None
+
+    def test_error_severity_has_warning_value(self) -> None:
+        """ErrorSeverity enum has WARNING member."""
+        assert hasattr(ErrorSeverity, "WARNING")
+        assert ErrorSeverity.WARNING is not None
+
+    def test_error_severity_error_string_value(self) -> None:
+        """ErrorSeverity.ERROR has value 'error'."""
+        assert ErrorSeverity.ERROR.value == "error"
+
+    def test_error_severity_warning_string_value(self) -> None:
+        """ErrorSeverity.WARNING has value 'warning'."""
+        assert ErrorSeverity.WARNING.value == "warning"
+
+
+class TestValidationError:
+    """Tests for ValidationError dataclass."""
+
+    def test_construction_with_required_fields(self) -> None:
+        """ValidationError can be constructed with only code and message."""
+        error = ValidationError(code="TEST001", message="Test error message")
+
+        assert error.code == "TEST001"
+        assert error.message == "Test error message"
+
+    def test_default_severity_is_error(self) -> None:
+        """ValidationError defaults severity to ERROR."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        assert error.severity == ErrorSeverity.ERROR
+
+    def test_default_file_is_none(self) -> None:
+        """ValidationError defaults file to None."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        assert error.file is None
+
+    def test_default_line_is_none(self) -> None:
+        """ValidationError defaults line to None."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        assert error.line is None
+
+    def test_default_column_is_none(self) -> None:
+        """ValidationError defaults column to None."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        assert error.column is None
+
+    def test_construction_with_all_fields(self) -> None:
+        """ValidationError accepts all fields including optional ones."""
+        error = ValidationError(
+            code="TEST001",
+            message="Test error",
+            file="test_file.py",
+            line=42,
+            column=10,
+            severity=ErrorSeverity.WARNING,
+        )
+
+        assert error.code == "TEST001"
+        assert error.message == "Test error"
+        assert error.file == "test_file.py"
+        assert error.line == 42
+        assert error.column == 10
+        assert error.severity == ErrorSeverity.WARNING
+
+    def test_to_dict_returns_dict(self) -> None:
+        """ValidationError.to_dict() returns a dictionary."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        result = error.to_dict()
+
+        assert isinstance(result, dict)
+
+    def test_to_dict_contains_code(self) -> None:
+        """ValidationError.to_dict() includes code field."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        result = error.to_dict()
+
+        assert result["code"] == "TEST001"
+
+    def test_to_dict_contains_message(self) -> None:
+        """ValidationError.to_dict() includes message field."""
+        error = ValidationError(code="TEST001", message="Test error message")
+
+        result = error.to_dict()
+
+        assert result["message"] == "Test error message"
+
+    def test_to_dict_contains_severity(self) -> None:
+        """ValidationError.to_dict() includes severity field as string."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        result = error.to_dict()
+
+        assert result["severity"] == "error"
+
+    def test_to_dict_includes_file_when_set(self) -> None:
+        """ValidationError.to_dict() includes file when provided."""
+        error = ValidationError(
+            code="TEST001", message="Test error", file="test_file.py"
+        )
+
+        result = error.to_dict()
+
+        assert result["file"] == "test_file.py"
+
+    def test_to_dict_includes_line_when_set(self) -> None:
+        """ValidationError.to_dict() includes line when provided."""
+        error = ValidationError(code="TEST001", message="Test error", line=42)
+
+        result = error.to_dict()
+
+        assert result["line"] == 42
+
+    def test_to_dict_includes_column_when_set(self) -> None:
+        """ValidationError.to_dict() includes column when provided."""
+        error = ValidationError(code="TEST001", message="Test error", column=10)
+
+        result = error.to_dict()
+
+        assert result["column"] == 10
+
+    def test_to_dict_excludes_file_when_none(self) -> None:
+        """ValidationError.to_dict() excludes file when None."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        result = error.to_dict()
+
+        assert "file" not in result
+
+    def test_to_dict_excludes_line_when_none(self) -> None:
+        """ValidationError.to_dict() excludes line when None."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        result = error.to_dict()
+
+        assert "line" not in result
+
+    def test_to_dict_excludes_column_when_none(self) -> None:
+        """ValidationError.to_dict() excludes column when None."""
+        error = ValidationError(code="TEST001", message="Test error")
+
+        result = error.to_dict()
+
+        assert "column" not in result
+
+
+class TestValidationResult:
+    """Tests for ValidationResult dataclass."""
+
+    def test_default_success_is_true(self) -> None:
+        """ValidationResult defaults success to True."""
+        result = ValidationResult()
+
+        assert result.success is True
+
+    def test_default_errors_is_empty_list(self) -> None:
+        """ValidationResult defaults errors to empty list."""
+        result = ValidationResult()
+
+        assert result.errors == []
+
+    def test_default_warnings_is_empty_list(self) -> None:
+        """ValidationResult defaults warnings to empty list."""
+        result = ValidationResult()
+
+        assert result.warnings == []
+
+    def test_default_metadata_is_empty_dict(self) -> None:
+        """ValidationResult defaults metadata to empty dict."""
+        result = ValidationResult()
+
+        assert result.metadata == {}
+
+    def test_add_error_with_error_severity_sets_success_false(self) -> None:
+        """add_error() with ERROR severity sets success to False."""
+        result = ValidationResult()
+        error = ValidationError(
+            code="TEST001", message="Test error", severity=ErrorSeverity.ERROR
+        )
+
+        result.add_error(error)
+
+        assert result.success is False
+
+    def test_add_error_with_error_severity_adds_to_errors_list(self) -> None:
+        """add_error() with ERROR severity adds error to errors list."""
+        result = ValidationResult()
+        error = ValidationError(
+            code="TEST001", message="Test error", severity=ErrorSeverity.ERROR
+        )
+
+        result.add_error(error)
+
+        assert error in result.errors
+
+    def test_add_error_with_warning_severity_keeps_success_true(self) -> None:
+        """add_error() with WARNING severity keeps success True."""
+        result = ValidationResult()
+        warning = ValidationError(
+            code="WARN001", message="Test warning", severity=ErrorSeverity.WARNING
+        )
+
+        result.add_error(warning)
+
+        assert result.success is True
+
+    def test_add_error_with_warning_severity_adds_to_warnings_list(self) -> None:
+        """add_error() with WARNING severity adds to warnings list."""
+        result = ValidationResult()
+        warning = ValidationError(
+            code="WARN001", message="Test warning", severity=ErrorSeverity.WARNING
+        )
+
+        result.add_error(warning)
+
+        assert warning in result.warnings
+
+    def test_add_multiple_errors(self) -> None:
+        """add_error() can add multiple errors."""
+        result = ValidationResult()
+        error1 = ValidationError(code="TEST001", message="Error 1")
+        error2 = ValidationError(code="TEST002", message="Error 2")
+
+        result.add_error(error1)
+        result.add_error(error2)
+
+        assert len(result.errors) == 2
+        assert error1 in result.errors
+        assert error2 in result.errors
+
+    def test_add_mixed_errors_and_warnings(self) -> None:
+        """add_error() correctly separates errors and warnings."""
+        result = ValidationResult()
+        error = ValidationError(
+            code="ERR001", message="Error", severity=ErrorSeverity.ERROR
+        )
+        warning = ValidationError(
+            code="WARN001", message="Warning", severity=ErrorSeverity.WARNING
+        )
+
+        result.add_error(error)
+        result.add_error(warning)
+
+        assert len(result.errors) == 1
+        assert len(result.warnings) == 1
+        assert error in result.errors
+        assert warning in result.warnings
+
+    def test_to_dict_returns_dict(self) -> None:
+        """ValidationResult.to_dict() returns a dictionary."""
+        result = ValidationResult()
+
+        output = result.to_dict()
+
+        assert isinstance(output, dict)
+
+    def test_to_dict_contains_success(self) -> None:
+        """ValidationResult.to_dict() includes success field."""
+        result = ValidationResult()
+
+        output = result.to_dict()
+
+        assert "success" in output
+        assert output["success"] is True
+
+    def test_to_dict_contains_errors_array(self) -> None:
+        """ValidationResult.to_dict() includes errors as array."""
+        result = ValidationResult()
+        error = ValidationError(code="TEST001", message="Error")
+        result.add_error(error)
+
+        output = result.to_dict()
+
+        assert "errors" in output
+        assert isinstance(output["errors"], list)
+        assert len(output["errors"]) == 1
+
+    def test_to_dict_contains_warnings_array(self) -> None:
+        """ValidationResult.to_dict() includes warnings as array."""
+        result = ValidationResult()
+        warning = ValidationError(
+            code="WARN001", message="Warning", severity=ErrorSeverity.WARNING
+        )
+        result.add_error(warning)
+
+        output = result.to_dict()
+
+        assert "warnings" in output
+        assert isinstance(output["warnings"], list)
+        assert len(output["warnings"]) == 1
+
+    def test_to_dict_contains_metadata(self) -> None:
+        """ValidationResult.to_dict() includes metadata."""
+        result = ValidationResult()
+        result.metadata["manifest"] = "task-142.manifest.json"
+
+        output = result.to_dict()
+
+        assert "metadata" in output
+        assert output["metadata"]["manifest"] == "task-142.manifest.json"
+
+    def test_to_dict_serializes_error_objects(self) -> None:
+        """ValidationResult.to_dict() converts error objects to dicts."""
+        result = ValidationResult()
+        error = ValidationError(code="TEST001", message="Error", file="test.py")
+        result.add_error(error)
+
+        output = result.to_dict()
+
+        error_dict = output["errors"][0]
+        assert error_dict["code"] == "TEST001"
+        assert error_dict["message"] == "Error"
+        assert error_dict["file"] == "test.py"
+
+    def test_to_json_returns_string(self) -> None:
+        """ValidationResult.to_json() returns a string."""
+        result = ValidationResult()
+
+        output = result.to_json()
+
+        assert isinstance(output, str)
+
+    def test_to_json_returns_valid_json(self) -> None:
+        """ValidationResult.to_json() returns parseable JSON."""
+        result = ValidationResult()
+        error = ValidationError(code="TEST001", message="Error")
+        result.add_error(error)
+
+        output = result.to_json()
+        parsed = json.loads(output)
+
+        assert parsed["success"] is False
+        assert len(parsed["errors"]) == 1
+
+    def test_to_json_with_indent_returns_formatted_json(self) -> None:
+        """ValidationResult.to_json(indent=2) returns formatted JSON."""
+        result = ValidationResult()
+
+        output = result.to_json(indent=2)
+
+        # Formatted JSON has newlines
+        assert "\n" in output
+        # Check indentation
+        lines = output.split("\n")
+        # At least one line should be indented with 2 spaces
+        assert any(line.startswith("  ") for line in lines)
+
+    def test_to_json_without_indent_returns_compact_json(self) -> None:
+        """ValidationResult.to_json() without indent returns compact JSON."""
+        result = ValidationResult()
+        result.metadata["key"] = "value"
+
+        output = result.to_json()
+
+        # Compact JSON has no newlines (or minimal newlines)
+        # json.dumps without indent produces single-line output
+        assert output.count("\n") == 0
+
+    def test_lsp_compatible_format(self) -> None:
+        """ValidationResult.to_dict() produces maid-lsp compatible format."""
+        result = ValidationResult()
+        error = ValidationError(
+            code="MAID001",
+            message="Missing artifact",
+            file="src/module.py",
+            line=10,
+            column=5,
+            severity=ErrorSeverity.ERROR,
+        )
+        result.add_error(error)
+        result.metadata["manifest"] = "task-142.manifest.json"
+        result.metadata["validationMode"] = "implementation"
+
+        output = result.to_dict()
+
+        # Check LSP-compatible structure
+        assert output["success"] is False
+        assert isinstance(output["errors"], list)
+        assert isinstance(output["warnings"], list)
+        assert isinstance(output["metadata"], dict)
+
+        # Check error format
+        error_dict = output["errors"][0]
+        assert error_dict["code"] == "MAID001"
+        assert error_dict["message"] == "Missing artifact"
+        assert error_dict["file"] == "src/module.py"
+        assert error_dict["line"] == 10
+        assert error_dict["column"] == 5
+        assert error_dict["severity"] == "error"

--- a/tests/test_task_142_validation_result.py
+++ b/tests/test_task_142_validation_result.py
@@ -1,16 +1,64 @@
 """Behavioral tests for validation result types (Task-142).
 
-Tests the ErrorSeverity enum, ValidationError dataclass, and ValidationResult dataclass
-that provide structured validation output for maid-lsp compatibility.
+Tests the ErrorCode constants, ErrorSeverity enum, ValidationError dataclass,
+and ValidationResult dataclass that provide structured validation output for
+maid-lsp compatibility.
 """
 
 import json
 
 from maid_runner.validation_result import (
+    ErrorCode,
     ErrorSeverity,
     ValidationError,
     ValidationResult,
 )
+
+
+class TestErrorCode:
+    """Tests for ErrorCode constants."""
+
+    def test_error_code_class_exists(self) -> None:
+        """ErrorCode class should exist and be importable."""
+        assert ErrorCode is not None
+        # Verify it's a class with the expected attributes
+        assert hasattr(ErrorCode, "FILE_NOT_FOUND")
+
+    def test_file_not_found_code(self) -> None:
+        """ErrorCode.FILE_NOT_FOUND should be E001."""
+        assert ErrorCode.FILE_NOT_FOUND == "E001"
+
+    def test_schema_validation_failed_code(self) -> None:
+        """ErrorCode.SCHEMA_VALIDATION_FAILED should be E002."""
+        assert ErrorCode.SCHEMA_VALIDATION_FAILED == "E002"
+
+    def test_semantic_validation_failed_code(self) -> None:
+        """ErrorCode.SEMANTIC_VALIDATION_FAILED should be E101."""
+        assert ErrorCode.SEMANTIC_VALIDATION_FAILED == "E101"
+
+    def test_supersession_validation_failed_code(self) -> None:
+        """ErrorCode.SUPERSESSION_VALIDATION_FAILED should be E102."""
+        assert ErrorCode.SUPERSESSION_VALIDATION_FAILED == "E102"
+
+    def test_artifact_not_found_code(self) -> None:
+        """ErrorCode.ARTIFACT_NOT_FOUND should be E301."""
+        assert ErrorCode.ARTIFACT_NOT_FOUND == "E301"
+
+    def test_alignment_error_code(self) -> None:
+        """ErrorCode.ALIGNMENT_ERROR should be E308."""
+        assert ErrorCode.ALIGNMENT_ERROR == "E308"
+
+    def test_unexpected_error_code(self) -> None:
+        """ErrorCode.UNEXPECTED_ERROR should be E999."""
+        assert ErrorCode.UNEXPECTED_ERROR == "E999"
+
+    def test_can_use_error_code_in_validation_error(self) -> None:
+        """ErrorCode constants can be used to construct ValidationError."""
+        error = ValidationError(
+            code=ErrorCode.FILE_NOT_FOUND,
+            message="File not found",
+        )
+        assert error.code == "E001"
 
 
 class TestErrorSeverity:

--- a/tests/test_task_143_list_manifests_json_output.py
+++ b/tests/test_task_143_list_manifests_json_output.py
@@ -1,0 +1,337 @@
+"""Behavioral tests for Task-143: List manifests JSON output.
+
+Tests the format_manifests_json function and the json_output parameter
+for run_list_manifests, enabling the maid-lsp server to receive manifest
+paths in machine-readable JSON format.
+"""
+
+import inspect
+import json
+
+
+class TestFormatManifestsJsonFunction:
+    """Tests for the format_manifests_json function."""
+
+    def test_format_manifests_json_exists(self):
+        """Test that format_manifests_json function exists and can be imported."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        assert callable(format_manifests_json)
+
+    def test_format_manifests_json_signature(self):
+        """Test that format_manifests_json has the expected signature."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        sig = inspect.signature(format_manifests_json)
+        params = list(sig.parameters.keys())
+
+        assert "categorized_manifests" in params
+        assert "manifest_dir" in params
+        assert sig.parameters["categorized_manifests"].annotation is dict
+        assert sig.parameters["manifest_dir"].annotation is str
+
+    def test_format_manifests_json_returns_valid_json(self):
+        """Test that format_manifests_json returns a valid JSON string."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        categorized = {
+            "created": ["task-001.manifest.json"],
+            "edited": [],
+            "read": [],
+        }
+
+        result = format_manifests_json(categorized, "manifests")
+
+        # Should be a valid JSON string
+        parsed = json.loads(result)
+        assert isinstance(parsed, list)
+
+    def test_format_manifests_json_empty_categories_returns_empty_array(self):
+        """Test that empty categories returns an empty JSON array."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        categorized = {
+            "created": [],
+            "edited": [],
+            "read": [],
+        }
+
+        result = format_manifests_json(categorized, "manifests")
+
+        assert result == "[]"
+
+    def test_format_manifests_json_single_manifest_in_created(self):
+        """Test that single manifest in created returns array with one path."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        categorized = {
+            "created": ["task-001.manifest.json"],
+            "edited": [],
+            "read": [],
+        }
+
+        result = format_manifests_json(categorized, "manifests")
+        parsed = json.loads(result)
+
+        assert len(parsed) == 1
+        assert parsed[0] == "manifests/task-001.manifest.json"
+
+    def test_format_manifests_json_multiple_manifests_across_categories(self):
+        """Test that multiple manifests across categories returns flat array."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        categorized = {
+            "created": ["task-001.manifest.json"],
+            "edited": ["task-002.manifest.json"],
+            "read": ["task-003.manifest.json", "task-004.manifest.json"],
+        }
+
+        result = format_manifests_json(categorized, "manifests")
+        parsed = json.loads(result)
+
+        assert len(parsed) == 4
+        assert "manifests/task-001.manifest.json" in parsed
+        assert "manifests/task-002.manifest.json" in parsed
+        assert "manifests/task-003.manifest.json" in parsed
+        assert "manifests/task-004.manifest.json" in parsed
+
+    def test_format_manifests_json_paths_constructed_correctly(self):
+        """Test that paths are constructed from manifest_dir + manifest_name."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        categorized = {
+            "created": ["task-001.manifest.json"],
+            "edited": [],
+            "read": [],
+        }
+
+        # Test with different manifest_dir values
+        result1 = format_manifests_json(categorized, "manifests")
+        result2 = format_manifests_json(categorized, "custom/path")
+
+        parsed1 = json.loads(result1)
+        parsed2 = json.loads(result2)
+
+        assert parsed1[0] == "manifests/task-001.manifest.json"
+        assert parsed2[0] == "custom/path/task-001.manifest.json"
+
+    def test_format_manifests_json_deduplicates_manifests(self):
+        """Test that duplicate manifests across categories are deduplicated."""
+        from maid_runner.cli.list_manifests import format_manifests_json
+
+        # Same manifest might appear in multiple categories theoretically
+        categorized = {
+            "created": ["task-001.manifest.json"],
+            "edited": ["task-001.manifest.json"],  # Duplicate
+            "read": ["task-002.manifest.json"],
+        }
+
+        result = format_manifests_json(categorized, "manifests")
+        parsed = json.loads(result)
+
+        # Should only have 2 unique paths
+        assert len(parsed) == 2
+        assert len(set(parsed)) == 2  # All unique
+
+
+class TestRunListManifestsJsonOutput:
+    """Tests for run_list_manifests with json_output parameter."""
+
+    def test_run_list_manifests_has_json_output_parameter(self):
+        """Test that run_list_manifests accepts json_output parameter."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        sig = inspect.signature(run_list_manifests)
+        params = list(sig.parameters.keys())
+
+        assert "json_output" in params
+        assert sig.parameters["json_output"].annotation is bool
+
+    def test_run_list_manifests_json_output_prints_json_array(self, tmp_path, capsys):
+        """Test that json_output=True prints JSON array to stdout."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        manifest_dir = tmp_path / "manifests"
+        manifest_dir.mkdir()
+
+        manifest1 = {
+            "goal": "Create test.py",
+            "creatableFiles": ["test.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+        }
+
+        with open(manifest_dir / "task-001.manifest.json", "w") as f:
+            json.dump(manifest1, f)
+
+        run_list_manifests("test.py", str(manifest_dir), quiet=False, json_output=True)
+
+        captured = capsys.readouterr()
+        output = captured.out.strip()
+
+        # Should be valid JSON array
+        parsed = json.loads(output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+    def test_run_list_manifests_json_output_no_manifests_prints_empty_array(
+        self, tmp_path, capsys
+    ):
+        """Test that json_output=True with no matches prints empty JSON array."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        manifest_dir = tmp_path / "manifests"
+        manifest_dir.mkdir()
+
+        manifest1 = {
+            "goal": "Create other.py",
+            "creatableFiles": ["other.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+        }
+
+        with open(manifest_dir / "task-001.manifest.json", "w") as f:
+            json.dump(manifest1, f)
+
+        run_list_manifests(
+            "not_found.py", str(manifest_dir), quiet=False, json_output=True
+        )
+
+        captured = capsys.readouterr()
+        output = captured.out.strip()
+
+        assert output == "[]"
+
+    def test_run_list_manifests_json_false_prints_formatted_text(
+        self, tmp_path, capsys
+    ):
+        """Test that json_output=False prints formatted text (existing behavior)."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        manifest_dir = tmp_path / "manifests"
+        manifest_dir.mkdir()
+
+        manifest1 = {
+            "goal": "Create test.py",
+            "creatableFiles": ["test.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+        }
+
+        with open(manifest_dir / "task-001.manifest.json", "w") as f:
+            json.dump(manifest1, f)
+
+        run_list_manifests("test.py", str(manifest_dir), quiet=False, json_output=False)
+
+        captured = capsys.readouterr()
+        output = captured.out
+
+        # Should NOT be a plain JSON array - should have formatted text
+        # Should contain manifest reference and decorative text
+        assert "task-001" in output
+        # Verify it's not just a JSON array (formatted output has more content)
+        assert "test.py" in output or "CREATED" in output.upper()
+
+    def test_run_list_manifests_json_output_valid_parseable_json(
+        self, tmp_path, capsys
+    ):
+        """Test that JSON output is valid and parseable."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        manifest_dir = tmp_path / "manifests"
+        manifest_dir.mkdir()
+
+        manifest1 = {
+            "goal": "Create test.py",
+            "creatableFiles": ["test.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+        }
+
+        manifest2 = {
+            "goal": "Edit test.py",
+            "creatableFiles": [],
+            "editableFiles": ["test.py"],
+            "readonlyFiles": [],
+        }
+
+        with open(manifest_dir / "task-001.manifest.json", "w") as f:
+            json.dump(manifest1, f)
+
+        with open(manifest_dir / "task-002.manifest.json", "w") as f:
+            json.dump(manifest2, f)
+
+        run_list_manifests("test.py", str(manifest_dir), quiet=False, json_output=True)
+
+        captured = capsys.readouterr()
+        output = captured.out.strip()
+
+        # Should be valid JSON
+        parsed = json.loads(output)
+
+        # Should be a list of strings
+        assert isinstance(parsed, list)
+        assert all(isinstance(p, str) for p in parsed)
+
+        # Should contain full paths
+        assert len(parsed) == 2
+        assert any("task-001" in p for p in parsed)
+        assert any("task-002" in p for p in parsed)
+
+    def test_run_list_manifests_json_output_contains_full_paths(self, tmp_path, capsys):
+        """Test that JSON output contains full manifest paths with directory."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        manifest_dir = tmp_path / "manifests"
+        manifest_dir.mkdir()
+
+        manifest1 = {
+            "goal": "Create test.py",
+            "creatableFiles": ["test.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+        }
+
+        with open(manifest_dir / "task-001.manifest.json", "w") as f:
+            json.dump(manifest1, f)
+
+        run_list_manifests("test.py", str(manifest_dir), quiet=False, json_output=True)
+
+        captured = capsys.readouterr()
+        output = captured.out.strip()
+        parsed = json.loads(output)
+
+        # Path should include the manifest directory
+        assert len(parsed) == 1
+        assert str(manifest_dir) in parsed[0]
+        assert "task-001.manifest.json" in parsed[0]
+
+
+class TestRunListManifestsBackwardCompatibility:
+    """Tests ensuring backward compatibility when json_output is not provided."""
+
+    def test_run_list_manifests_works_without_json_output_kwarg(self, tmp_path, capsys):
+        """Test that run_list_manifests works when json_output is omitted."""
+        from maid_runner.cli.list_manifests import run_list_manifests
+
+        manifest_dir = tmp_path / "manifests"
+        manifest_dir.mkdir()
+
+        manifest1 = {
+            "goal": "Create test.py",
+            "creatableFiles": ["test.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+        }
+
+        with open(manifest_dir / "task-001.manifest.json", "w") as f:
+            json.dump(manifest1, f)
+
+        # Call without json_output - should use default behavior (text output)
+        sig = inspect.signature(run_list_manifests)
+        if "json_output" in sig.parameters:
+            # Check if it has a default value
+            param = sig.parameters["json_output"]
+            assert (
+                param.default is not inspect.Parameter.empty
+            ), "json_output should have a default value for backward compatibility"

--- a/tests/test_task_144_json_output.py
+++ b/tests/test_task_144_json_output.py
@@ -1,0 +1,439 @@
+"""Behavioral tests for task-144: JSON output formatting for maid validate.
+
+Tests the format_validation_json function that formats validation results
+as JSON string compatible with maid-lsp expectations.
+"""
+
+import json
+from typing import Any
+
+
+from maid_runner.cli.validate import format_validation_json
+from maid_runner.validation_result import ErrorSeverity, ValidationError
+
+
+class TestFormatValidationJsonExists:
+    """Test that format_validation_json exists and is callable."""
+
+    def test_function_exists(self) -> None:
+        """format_validation_json should be importable from validate module."""
+        assert format_validation_json is not None
+
+    def test_function_is_callable(self) -> None:
+        """format_validation_json should be callable."""
+        assert callable(format_validation_json)
+
+
+class TestFormatValidationJsonReturnsValidJson:
+    """Test that format_validation_json returns valid JSON strings."""
+
+    def test_returns_valid_json_string(self) -> None:
+        """Result should be parseable as valid JSON."""
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+        assert isinstance(parsed, dict)
+
+    def test_returns_string_type(self) -> None:
+        """Result should be a string."""
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata={}
+        )
+        assert isinstance(result, str)
+
+
+class TestFormatValidationJsonEmptyCase:
+    """Test format_validation_json with empty errors/warnings."""
+
+    def test_empty_errors_warnings_returns_proper_structure(self) -> None:
+        """Empty errors/warnings should return proper structure."""
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["errors"] == []
+        assert parsed["warnings"] == []
+        assert parsed["metadata"] == {}
+
+    def test_all_required_keys_present(self) -> None:
+        """Result should have all required keys: success, errors, warnings, metadata."""
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert "success" in parsed
+        assert "errors" in parsed
+        assert "warnings" in parsed
+        assert "metadata" in parsed
+
+
+class TestFormatValidationJsonSingleError:
+    """Test format_validation_json with a single error."""
+
+    def test_single_error_includes_all_fields(self) -> None:
+        """Single error should include code, message, file, line, column, severity."""
+        error = ValidationError(
+            code="E301",
+            message="Missing artifact",
+            file="path/to/file.py",
+            line=42,
+            column=1,
+            severity=ErrorSeverity.ERROR,
+        )
+        result = format_validation_json(
+            success=False, errors=[error], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert len(parsed["errors"]) == 1
+        err = parsed["errors"][0]
+        assert err["code"] == "E301"
+        assert err["message"] == "Missing artifact"
+        assert err["file"] == "path/to/file.py"
+        assert err["line"] == 42
+        assert err["column"] == 1
+        assert err["severity"] == "error"
+
+    def test_error_severity_is_string(self) -> None:
+        """Error severity should be serialized as string value."""
+        error = ValidationError(
+            code="E001",
+            message="Test error",
+            file="test.py",
+            line=1,
+            column=1,
+            severity=ErrorSeverity.ERROR,
+        )
+        result = format_validation_json(
+            success=False, errors=[error], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert parsed["errors"][0]["severity"] == "error"
+
+
+class TestFormatValidationJsonMultipleErrors:
+    """Test format_validation_json with multiple errors."""
+
+    def test_multiple_errors_serialized_as_array(self) -> None:
+        """Multiple errors should be serialized as an array."""
+        errors = [
+            ValidationError(
+                code="E001",
+                message="First error",
+                file="file1.py",
+                line=10,
+                column=1,
+                severity=ErrorSeverity.ERROR,
+            ),
+            ValidationError(
+                code="E002",
+                message="Second error",
+                file="file2.py",
+                line=20,
+                column=5,
+                severity=ErrorSeverity.ERROR,
+            ),
+        ]
+        result = format_validation_json(
+            success=False, errors=errors, warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert len(parsed["errors"]) == 2
+        assert parsed["errors"][0]["code"] == "E001"
+        assert parsed["errors"][1]["code"] == "E002"
+
+    def test_multiple_errors_preserves_order(self) -> None:
+        """Multiple errors should preserve their order."""
+        errors = [
+            ValidationError(code=f"E{i:03d}", message=f"Error {i}") for i in range(5)
+        ]
+        result = format_validation_json(
+            success=False, errors=errors, warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        for i, err in enumerate(parsed["errors"]):
+            assert err["code"] == f"E{i:03d}"
+
+
+class TestFormatValidationJsonWarnings:
+    """Test format_validation_json with warnings."""
+
+    def test_warnings_go_into_warnings_array(self) -> None:
+        """Warnings should be placed in the warnings array."""
+        warning = ValidationError(
+            code="W001",
+            message="Warning message",
+            file="warn.py",
+            line=5,
+            column=1,
+            severity=ErrorSeverity.WARNING,
+        )
+        result = format_validation_json(
+            success=True, errors=[], warnings=[warning], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert len(parsed["warnings"]) == 1
+        assert parsed["warnings"][0]["code"] == "W001"
+        assert parsed["warnings"][0]["severity"] == "warning"
+
+    def test_multiple_warnings(self) -> None:
+        """Multiple warnings should be serialized correctly."""
+        warnings = [
+            ValidationError(
+                code="W001",
+                message="First warning",
+                severity=ErrorSeverity.WARNING,
+            ),
+            ValidationError(
+                code="W002",
+                message="Second warning",
+                severity=ErrorSeverity.WARNING,
+            ),
+        ]
+        result = format_validation_json(
+            success=True, errors=[], warnings=warnings, metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert len(parsed["warnings"]) == 2
+
+
+class TestFormatValidationJsonMetadata:
+    """Test format_validation_json with metadata."""
+
+    def test_metadata_dict_included_in_output(self) -> None:
+        """Metadata dict should be included in output."""
+        metadata = {
+            "manifest_path": "manifests/task-001.manifest.json",
+            "validation_mode": "implementation",
+        }
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata=metadata
+        )
+        parsed = json.loads(result)
+
+        assert parsed["metadata"]["manifest_path"] == "manifests/task-001.manifest.json"
+        assert parsed["metadata"]["validation_mode"] == "implementation"
+
+    def test_complex_metadata(self) -> None:
+        """Complex metadata with nested values should be serialized."""
+        metadata = {
+            "manifest_path": "manifests/task-042.manifest.json",
+            "validation_mode": "behavioral",
+            "extra_info": "additional data",
+        }
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata=metadata
+        )
+        parsed = json.loads(result)
+
+        assert parsed["metadata"] == metadata
+
+
+class TestFormatValidationJsonSuccessFlag:
+    """Test format_validation_json success flag behavior."""
+
+    def test_success_false_reflected_in_json(self) -> None:
+        """success=False should be correctly reflected in JSON."""
+        result = format_validation_json(
+            success=False, errors=[], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+
+    def test_success_true_reflected_in_json(self) -> None:
+        """success=True should be correctly reflected in JSON."""
+        result = format_validation_json(
+            success=True, errors=[], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+
+
+class TestFormatValidationJsonNullFields:
+    """Test format_validation_json with None values in ValidationError."""
+
+    def test_none_file_handled_gracefully(self) -> None:
+        """ValidationError with None file should be handled gracefully."""
+        error = ValidationError(
+            code="E001",
+            message="Error without file",
+            file=None,
+            line=None,
+            column=None,
+            severity=ErrorSeverity.ERROR,
+        )
+        result = format_validation_json(
+            success=False, errors=[error], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        # Should not raise an exception and should produce valid JSON
+        assert len(parsed["errors"]) == 1
+        assert parsed["errors"][0]["code"] == "E001"
+        assert parsed["errors"][0]["message"] == "Error without file"
+        # file, line, column should either be null/None or omitted
+        # Based on ValidationError.to_dict(), they are omitted when None
+        assert "file" not in parsed["errors"][0] or parsed["errors"][0]["file"] is None
+
+    def test_partial_location_info(self) -> None:
+        """ValidationError with only some location info should be handled."""
+        error = ValidationError(
+            code="E001",
+            message="Partial location",
+            file="test.py",
+            line=10,
+            column=None,
+            severity=ErrorSeverity.ERROR,
+        )
+        result = format_validation_json(
+            success=False, errors=[error], warnings=[], metadata={}
+        )
+        parsed = json.loads(result)
+
+        err = parsed["errors"][0]
+        assert err["file"] == "test.py"
+        assert err["line"] == 10
+        # column should be omitted or None
+        assert "column" not in err or err["column"] is None
+
+
+class TestFormatValidationJsonMaidLspFormat:
+    """Test that output matches maid-lsp expected format exactly."""
+
+    def test_full_output_matches_expected_format(self) -> None:
+        """Full output should match maid-lsp expected format."""
+        error = ValidationError(
+            code="E301",
+            message="Missing function definition",
+            file="path/to/module.py",
+            line=42,
+            column=1,
+            severity=ErrorSeverity.ERROR,
+        )
+        warning = ValidationError(
+            code="W101",
+            message="Consider adding docstring",
+            file="path/to/module.py",
+            line=50,
+            column=1,
+            severity=ErrorSeverity.WARNING,
+        )
+        metadata = {
+            "manifest_path": "manifests/task-001.manifest.json",
+            "validation_mode": "implementation",
+        }
+
+        result = format_validation_json(
+            success=False, errors=[error], warnings=[warning], metadata=metadata
+        )
+        parsed = json.loads(result)
+
+        # Verify structure matches expected format:
+        # {
+        #   "success": true/false,
+        #   "errors": [{"code": "...", "message": "...", "file": "...",
+        #               "line": ..., "column": ..., "severity": "error"}],
+        #   "warnings": [...],
+        #   "metadata": {"manifest_path": "...", "validation_mode": "..."}
+        # }
+        assert isinstance(parsed["success"], bool)
+        assert isinstance(parsed["errors"], list)
+        assert isinstance(parsed["warnings"], list)
+        assert isinstance(parsed["metadata"], dict)
+
+        # Verify error structure
+        err = parsed["errors"][0]
+        assert "code" in err
+        assert "message" in err
+        assert "severity" in err
+        assert err["severity"] in ["error", "warning"]
+
+        # Verify warning structure
+        warn = parsed["warnings"][0]
+        assert "code" in warn
+        assert "message" in warn
+        assert warn["severity"] == "warning"
+
+    def test_json_keys_are_strings(self) -> None:
+        """All JSON keys should be strings (standard JSON format)."""
+        result = format_validation_json(
+            success=True,
+            errors=[ValidationError(code="E001", message="Test")],
+            warnings=[],
+            metadata={"key": "value"},
+        )
+        parsed = json.loads(result)
+
+        def check_keys(obj: Any, path: str = "") -> None:
+            if isinstance(obj, dict):
+                for key in obj.keys():
+                    assert isinstance(key, str), f"Key at {path} is not a string"
+                    check_keys(obj[key], f"{path}.{key}")
+            elif isinstance(obj, list):
+                for i, item in enumerate(obj):
+                    check_keys(item, f"{path}[{i}]")
+
+        check_keys(parsed)
+
+
+class TestRunValidationJsonOutputParameter:
+    """Test that run_validation accepts json_output parameter."""
+
+    def test_run_validation_has_json_output_parameter(self) -> None:
+        """run_validation should accept json_output parameter."""
+        import inspect
+        from maid_runner.cli.validate import run_validation
+
+        sig = inspect.signature(run_validation)
+        params = list(sig.parameters.keys())
+        assert "json_output" in params
+
+    def test_run_validation_json_output_default_is_false(self) -> None:
+        """run_validation json_output parameter should default to False."""
+        import inspect
+        from maid_runner.cli.validate import run_validation
+
+        sig = inspect.signature(run_validation)
+        json_output_param = sig.parameters["json_output"]
+        assert json_output_param.default is False
+
+    def test_run_validation_is_callable(self) -> None:
+        """run_validation should be callable."""
+        from maid_runner.cli.validate import run_validation
+
+        assert callable(run_validation)
+
+    def test_run_validation_accepts_json_output_kwarg(self, tmp_path) -> None:
+        """run_validation should accept json_output keyword argument without error."""
+        import pytest
+        from maid_runner.cli.validate import run_validation
+
+        # Create a minimal valid manifest for testing
+        manifest_path = tmp_path / "test.manifest.json"
+        manifest_path.write_text(
+            '{"goal": "test", "taskType": "create", "creatableFiles": [], '
+            '"editableFiles": [], "readonlyFiles": [], '
+            '"expectedArtifacts": {"file": "test.py", "contains": []}, '
+            '"validationCommand": ["echo", "ok"]}'
+        )
+
+        # Call run_validation with json_output parameter
+        # It will exit because the manifest references a non-existent file,
+        # but the important thing is it accepts the parameter
+        with pytest.raises(SystemExit):
+            run_validation(
+                manifest_path=str(manifest_path),
+                validation_mode="implementation",
+                json_output=True,
+            )


### PR DESCRIPTION
## Summary

- Add `--json-output` flag to `maid manifests` command for machine-readable output
- Add `--json-output` flag to `maid validate` command for structured JSON output
- Create `ValidationResult`, `ValidationError`, and `ErrorSeverity` types for LSP-compatible error reporting
- Fix validator to detect enum members and dataclass fields

## Context

This PR implements GitHub issue #46 (Advanced Reporting Formats) to support integration with the `maid-lsp` Language Server Protocol implementation.

The `maid-lsp` server needs to call maid-runner CLI commands and parse structured JSON output for IDE integration features like real-time validation diagnostics.

## Changes

### New Types (`maid_runner/validation_result.py`)
- `ErrorSeverity` enum: ERROR, WARNING
- `ValidationError` dataclass: code, message, file, line, column, severity
- `ValidationResult` dataclass: success, errors, warnings, metadata

### CLI Flags
- `maid manifests <file> --json-output` → Returns JSON array of manifest paths
- `maid validate <manifest> --json-output` → Returns structured validation result

### Output Formats

**`maid manifests --json-output`:**
```json
["manifests/task-001.manifest.json", "manifests/task-002.manifest.json"]
```

**`maid validate --json-output`:**
```json
{
  "success": false,
  "errors": [{"code": "E301", "message": "...", "file": "...", "line": 42, "severity": "error"}],
  "warnings": [],
  "metadata": {"manifest_path": "...", "validation_mode": "..."}
}
```

## Test plan

- [x] All 135 MAID manifests pass validation (100%)
- [x] All 150 validation commands pass
- [x] New behavioral tests for tasks 142, 143, 144
- [x] Linting passes
- [x] Verify `maid manifests --json-output` returns valid JSON array
- [x] Verify `maid validate --json-output` returns valid JSON object

Closes #46