### PR TITLE
feat: skip validation for superseded manifests in JSON output mode

### DIFF
--- a/maid_runner/validation_result.py
+++ b/maid_runner/validation_result.py
@@ -12,6 +12,9 @@ Error Code Reference:
         E101: MAID semantic validation failed (e.g., multi-file artifacts)
         E102: Supersession validation failed
 
+    I1XX - Informational codes (warnings):
+        I103: Manifest is superseded and excluded from active validation
+
     E3XX - Implementation validation errors:
         E301: Expected artifact not found in implementation
         E308: Alignment error during validation
@@ -43,6 +46,9 @@ class ErrorCode:
     # Semantic validation errors (E1XX)
     SEMANTIC_VALIDATION_FAILED = "E101"
     SUPERSESSION_VALIDATION_FAILED = "E102"
+
+    # Informational codes (I1XX) - used as warnings
+    SUPERSEDED_MANIFEST = "I103"
 
     # Implementation validation errors (E3XX)
     ARTIFACT_NOT_FOUND = "E301"

--- a/manifests/task-145-skip-superseded-manifest-validation.manifest.json
+++ b/manifests/task-145-skip-superseded-manifest-validation.manifest.json
@@ -1,0 +1,25 @@
+{
+  "goal": "Add superseded manifest detection to single-manifest validation. When validating a manifest that has been superseded by another manifest, return success with an informational warning instead of running validation. This prevents false positive errors for inactive manifests in LSP integration.",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validation_result.py",
+    "maid_runner/cli/validate.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/utils.py",
+    "tests/cli/test_task_145_skip_superseded_validation.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/cli/validate.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "_check_if_superseded",
+        "description": "Check if a manifest is superseded by another manifest. Returns tuple of (is_superseded, superseding_manifest_path)."
+      }
+    ]
+  },
+  "validationCommand": ["pytest", "tests/cli/test_task_145_skip_superseded_validation.py", "-v"]
+}

--- a/tests/cli/test_task_145_skip_superseded_validation.py
+++ b/tests/cli/test_task_145_skip_superseded_validation.py
@@ -1,0 +1,213 @@
+# tests/cli/test_task_145_skip_superseded_validation.py
+"""Behavioral tests for skipping validation of superseded manifests.
+
+When validating a manifest that has been superseded by another manifest,
+the validation should return success with an informational warning instead
+of running full validation. This prevents false positive errors for inactive
+manifests in LSP integration.
+"""
+
+import json
+from pathlib import Path
+
+from maid_runner.cli.validate import _check_if_superseded
+
+
+class TestCheckIfSuperseded:
+    """Tests for the _check_if_superseded function."""
+
+    def test_returns_true_when_manifest_is_superseded(self, tmp_path: Path):
+        """Test that function returns True when manifest is superseded by another."""
+        # Create a superseding manifest that supersedes task-001
+        superseding_manifest = {
+            "goal": "Superseding manifest",
+            "taskType": "edit",
+            "supersedes": ["manifests/task-001-example.manifest.json"],
+            "creatableFiles": [],
+            "editableFiles": ["src/example.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/example.py", "contains": []},
+        }
+
+        # Create a superseded manifest (task-001)
+        superseded_manifest = {
+            "goal": "Original manifest",
+            "taskType": "create",
+            "supersedes": [],
+            "creatableFiles": ["src/example.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/example.py", "contains": []},
+        }
+
+        # Write manifests to temp directory
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        superseded_path = manifests_dir / "task-001-example.manifest.json"
+        superseding_path = manifests_dir / "task-002-update.manifest.json"
+
+        superseded_path.write_text(json.dumps(superseded_manifest))
+        superseding_path.write_text(json.dumps(superseding_manifest))
+
+        # Check if task-001 is superseded
+        is_superseded, superseding_manifest_path = _check_if_superseded(
+            superseded_path, manifests_dir
+        )
+
+        assert is_superseded is True
+        assert superseding_manifest_path is not None
+        assert "task-002" in str(superseding_manifest_path)
+
+    def test_returns_false_when_manifest_is_not_superseded(self, tmp_path: Path):
+        """Test that function returns False when manifest is NOT superseded."""
+        # Create a manifest that is not superseded
+        active_manifest = {
+            "goal": "Active manifest",
+            "taskType": "create",
+            "supersedes": [],
+            "creatableFiles": ["src/module.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/module.py", "contains": []},
+        }
+
+        # Write manifest to temp directory
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        manifest_path = manifests_dir / "task-001-module.manifest.json"
+        manifest_path.write_text(json.dumps(active_manifest))
+
+        # Check if manifest is superseded
+        is_superseded, superseding_manifest_path = _check_if_superseded(
+            manifest_path, manifests_dir
+        )
+
+        assert is_superseded is False
+        assert superseding_manifest_path is None
+
+    def test_handles_transitive_supersession(self, tmp_path: Path):
+        """Test detection when manifest is superseded transitively.
+
+        If task-001 is superseded by task-002, and task-002 is superseded by task-003,
+        both task-001 and task-002 should be detected as superseded.
+        """
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # task-001: original
+        task_001 = {
+            "goal": "Original",
+            "taskType": "create",
+            "supersedes": [],
+            "creatableFiles": ["src/a.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/a.py", "contains": []},
+        }
+
+        # task-002: supersedes task-001
+        task_002 = {
+            "goal": "First update",
+            "taskType": "edit",
+            "supersedes": ["manifests/task-001-original.manifest.json"],
+            "creatableFiles": [],
+            "editableFiles": ["src/a.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/a.py", "contains": []},
+        }
+
+        # task-003: supersedes task-002
+        task_003 = {
+            "goal": "Second update",
+            "taskType": "edit",
+            "supersedes": ["manifests/task-002-update.manifest.json"],
+            "creatableFiles": [],
+            "editableFiles": ["src/a.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/a.py", "contains": []},
+        }
+
+        (manifests_dir / "task-001-original.manifest.json").write_text(
+            json.dumps(task_001)
+        )
+        (manifests_dir / "task-002-update.manifest.json").write_text(
+            json.dumps(task_002)
+        )
+        (manifests_dir / "task-003-final.manifest.json").write_text(
+            json.dumps(task_003)
+        )
+
+        # Both task-001 and task-002 should be detected as superseded
+        is_superseded_001, _ = _check_if_superseded(
+            manifests_dir / "task-001-original.manifest.json", manifests_dir
+        )
+        is_superseded_002, _ = _check_if_superseded(
+            manifests_dir / "task-002-update.manifest.json", manifests_dir
+        )
+        is_superseded_003, _ = _check_if_superseded(
+            manifests_dir / "task-003-final.manifest.json", manifests_dir
+        )
+
+        assert is_superseded_001 is True
+        assert is_superseded_002 is True
+        assert is_superseded_003 is False  # The final one is not superseded
+
+
+class TestValidationSkipsSupersededManifest:
+    """Tests that validation properly skips superseded manifests."""
+
+    def test_json_output_returns_success_for_superseded_manifest(self, tmp_path: Path):
+        """Test that JSON output returns success=True for superseded manifest."""
+        from maid_runner.cli.validate import _perform_core_validation
+
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+
+        # Create a superseded manifest
+        superseded_manifest = {
+            "goal": "Original manifest",
+            "taskType": "create",
+            "supersedes": [],
+            "creatableFiles": ["src/example.py"],
+            "editableFiles": [],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/example.py", "contains": []},
+        }
+
+        # Create a superseding manifest
+        superseding_manifest = {
+            "goal": "Superseding manifest",
+            "taskType": "edit",
+            "supersedes": ["manifests/task-001-example.manifest.json"],
+            "creatableFiles": [],
+            "editableFiles": ["src/example.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {"file": "src/example.py", "contains": []},
+        }
+
+        superseded_path = manifests_dir / "task-001-example.manifest.json"
+        superseding_path = manifests_dir / "task-002-update.manifest.json"
+
+        superseded_path.write_text(json.dumps(superseded_manifest))
+        superseding_path.write_text(json.dumps(superseding_manifest))
+
+        # Validate the superseded manifest - should return success
+        result = _perform_core_validation(
+            str(superseded_path),
+            validation_mode="implementation",
+            use_manifest_chain=False,
+            use_cache=False,
+        )
+
+        # Should succeed (not an error to validate a superseded manifest)
+        assert result.success is True
+
+        # Should have informational warning about being superseded
+        assert len(result.warnings) >= 1
+        warning_messages = [w.message for w in result.warnings]
+        assert any("superseded" in msg.lower() for msg in warning_messages)
+
+        # Metadata should indicate superseded status
+        assert result.metadata.get("is_superseded") is True


### PR DESCRIPTION
### **User description**
## Summary

- When validating a single manifest with `--json-output` that has been superseded by another manifest, return `success=true` with an informational warning instead of running full validation
- This prevents false positive errors for inactive manifests when used with LSP integration
- Add `_check_if_superseded()` function to detect superseded manifests
- Include metadata (`is_superseded`, `superseded_by`) in JSON output for LSP clients

## Problem

Previously, running `maid validate manifests/task-005-type-validation.manifest.json --json-output` on a superseded manifest would produce validation errors, even though superseded manifests are excluded from directory-level validation. This caused false positives in LSP integration.

## Solution

Add an early check in `_perform_core_validation()` that detects if the manifest is superseded and returns success with an informational warning (code `I103`).

**Before:**
```json
{"success": false, "errors": [{"code": "E301", "message": "Type validation failed..."}]}
```

**After:**
```json
{
  "success": true,
  "errors": [],
  "warnings": [{"code": "I103", "message": "This manifest has been superseded by task-009-snapshot-manifest_validator.manifest.json and is excluded from active validation."}],
  "metadata": {"is_superseded": true, "superseded_by": "manifests/task-009-snapshot-manifest_validator.manifest.json"}
}
```

## Test plan

- [x] All 4 new behavioral tests pass
- [x] All 136 manifests pass validation (100%)
- [x] All 151 validation commands pass
- [x] Lint and type checks pass
- [x] Verified fix with actual superseded manifest (`task-005-type-validation.manifest.json`)


___

### **PR Type**
Enhancement


___

### **Description**
- Add early detection for superseded manifests in single-manifest validation

- Return success with informational warning (I103) instead of validation errors

- Include metadata (`is_superseded`, `superseded_by`) in JSON output for LSP clients

- Implement `_check_if_superseded()` function to identify superseding manifests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single Manifest Validation"] --> B["Check if Superseded"]
  B --> C{Is Superseded?}
  C -->|Yes| D["Return Success + Warning I103"]
  C -->|No| E["Run Full Validation"]
  D --> F["Include Metadata in JSON"]
  E --> G["Return Validation Result"]
  F --> H["JSON Output"]
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate.py</strong><dd><code>Add superseded manifest detection to validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

maid_runner/cli/validate.py

<ul><li>Add <code>_check_if_superseded()</code> function to detect if a manifest is <br>superseded by another<br> <li> Update <code>_perform_core_validation()</code> to check for superseded manifests <br>before validation<br> <li> Return early with success=true and informational warning (I103) for <br>superseded manifests<br> <li> Include <code>is_superseded</code> and <code>superseded_by</code> metadata in validation results</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/115/files#diff-0202b2e12cfbbab63f8638d7aab6f668b384f2555eb30f87e9bed470fdd19e31">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_145_skip_superseded_validation.py</strong><dd><code>Add behavioral tests for superseded manifest detection</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/cli/test_task_145_skip_superseded_validation.py

<ul><li>Add <code>TestCheckIfSuperseded</code> class with 3 unit tests for <br><code>_check_if_superseded()</code> function<br> <li> Test detection of directly superseded manifests<br> <li> Test detection of non-superseded manifests<br> <li> Test transitive supersession chains (task-001 → task-002 → task-003)<br> <li> Add <code>TestValidationSkipsSupersededManifest</code> class to verify JSON output <br>behavior<br> <li> Verify success=true and informational warnings for superseded <br>manifests</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/115/files#diff-0ca03411b5436dfdce9607a391f79c6ec06cba14e37e356ebb94369b1fed34c2">+213/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-145-skip-superseded-manifest-validation.manifest.json</strong><dd><code>Add task manifest for superseded manifest detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-145-skip-superseded-manifest-validation.manifest.json

<ul><li>Create manifest for task-145 documenting the superseded manifest <br>validation feature<br> <li> Specify editable files: <code>maid_runner/validation_result.py</code> and <br><code>maid_runner/cli/validate.py</code><br> <li> Specify readonly files: <code>maid_runner/utils.py</code> and test file<br> <li> Define expected artifact: <code>_check_if_superseded()</code> function in <br>validate.py<br> <li> Include pytest validation command for the new test suite</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/115/files#diff-eecb0b74fc626a78bed954ef0c0fdddcad30fefb1c2aac3409f8a81a1f2fc44e">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

