### PR TITLE
fix: exclude test files in validationCommand from untracked list

### DIFF
--- a/manifests/task-146-track-validationcommand-test-files.manifest.json
+++ b/manifests/task-146-track-validationcommand-test-files.manifest.json
@@ -1,0 +1,32 @@
+{
+  "goal": "Fix untracked test files false positive by extracting test files from validationCommand/validationCommands fields in collect_tracked_files()",
+  "description": "Test files referenced in validationCommand or validationCommands fields are incorrectly reported as UNTRACKED TEST FILES. The fix imports and uses extract_test_files_from_command() from _test_file_extraction.py to extract test files from validation commands and add them to the tracked_files dictionary.",
+  "taskType": "edit",
+  "supersedes": [],
+  "creatableFiles": [],
+  "editableFiles": [
+    "maid_runner/validators/file_tracker.py"
+  ],
+  "readonlyFiles": [
+    "maid_runner/cli/_test_file_extraction.py",
+    "tests/validators/test_task_036_separate_untracked_tests.py"
+  ],
+  "expectedArtifacts": {
+    "file": "maid_runner/validators/file_tracker.py",
+    "contains": [
+      {
+        "type": "function",
+        "name": "collect_tracked_files",
+        "args": [
+          {"name": "manifest_chain", "type": "List[dict]"}
+        ],
+        "returns": "Dict[str, dict]"
+      }
+    ]
+  },
+  "validationCommand": [
+    "pytest",
+    "tests/validators/test_task_146_track_validationcommand_test_files.py",
+    "-v"
+  ]
+}

--- a/tests/validators/test_task_146_track_validationcommand_test_files.py
+++ b/tests/validators/test_task_146_track_validationcommand_test_files.py
@@ -1,0 +1,346 @@
+# tests/validators/test_task_146_track_validationcommand_test_files.py
+"""Behavioral tests for tracking test files from validationCommand fields.
+
+Test files referenced in validationCommand or validationCommands fields should
+be tracked, not reported as UNTRACKED TEST FILES. This module tests that
+collect_tracked_files() and analyze_file_tracking() properly extract and track
+test files from validation commands.
+"""
+
+from pathlib import Path
+from maid_runner.validators.file_tracker import (
+    collect_tracked_files,
+    analyze_file_tracking,
+)
+
+
+# ============================================================================
+# Test collect_tracked_files() extracts test files from validationCommand
+# ============================================================================
+
+
+def test_collect_tracked_files_includes_test_from_validationcommand():
+    """Test that test files from validationCommand are included in tracked files."""
+    manifest_chain = [
+        {
+            "goal": "Create feature module",
+            "creatableFiles": ["src/module.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "src/module.py",
+                "contains": [{"type": "function", "name": "my_func"}],
+            },
+            "validationCommand": ["pytest", "tests/test_module.py", "-v"],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Test file from validationCommand should be tracked
+    assert "tests/test_module.py" in tracked
+    assert tracked["tests/test_module.py"]["has_tests"] is True
+
+
+def test_collect_tracked_files_includes_tests_from_validationcommands():
+    """Test that test files from validationCommands (array) are tracked."""
+    manifest_chain = [
+        {
+            "goal": "Create feature",
+            "creatableFiles": ["src/app.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "src/app.py",
+                "contains": [{"type": "function", "name": "run"}],
+            },
+            "validationCommands": [
+                ["pytest", "tests/test_app.py", "-v"],
+                ["pytest", "tests/test_integration.py", "-v"],
+            ],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Both test files from validationCommands should be tracked
+    assert "tests/test_app.py" in tracked
+    assert "tests/test_integration.py" in tracked
+
+
+def test_collect_tracked_files_handles_single_string_command():
+    """Test tracking test files from single-string command format."""
+    manifest_chain = [
+        {
+            "goal": "Create utility",
+            "creatableFiles": ["utils.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "utils.py",
+                "contains": [{"type": "function", "name": "helper"}],
+            },
+            "validationCommand": ["pytest tests/test_utils.py -v"],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Test file from single-string command should be tracked
+    assert "tests/test_utils.py" in tracked
+
+
+def test_collect_tracked_files_handles_node_id_format():
+    """Test tracking test files from pytest node ID format (file::class::method)."""
+    manifest_chain = [
+        {
+            "goal": "Create service",
+            "creatableFiles": ["service.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "service.py",
+                "contains": [{"type": "class", "name": "Service"}],
+            },
+            "validationCommand": [
+                "pytest",
+                "tests/test_service.py::TestService::test_method",
+                "-v",
+            ],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # File path extracted from node ID should be tracked
+    assert "tests/test_service.py" in tracked
+
+
+def test_collect_tracked_files_handles_uv_run_prefix():
+    """Test tracking test files from command with uv run prefix."""
+    manifest_chain = [
+        {
+            "goal": "Create handler",
+            "creatableFiles": ["handler.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "handler.py",
+                "contains": [{"type": "function", "name": "handle"}],
+            },
+            "validationCommand": ["uv", "run", "pytest", "tests/test_handler.py", "-v"],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Test file after uv run prefix should be tracked
+    assert "tests/test_handler.py" in tracked
+
+
+# ============================================================================
+# Test analyze_file_tracking() does NOT report validationCommand tests as untracked
+# ============================================================================
+
+
+def test_analyze_file_tracking_validationcommand_tests_not_in_untracked(
+    tmp_path: Path,
+):
+    """Test that test files from validationCommand do NOT appear in untracked_tests."""
+    # Create the test file in the filesystem
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_feature.py").write_text("# test file")
+
+    manifest_chain = [
+        {
+            "goal": "Create feature",
+            "creatableFiles": ["feature.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "feature.py",
+                "contains": [{"type": "function", "name": "run"}],
+            },
+            "validationCommand": ["pytest", "tests/test_feature.py", "-v"],
+        }
+    ]
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    # Test file should be tracked, NOT in untracked_tests
+    assert "tests/test_feature.py" not in analysis["untracked_tests"]
+    assert "tests/test_feature.py" in analysis["tracked"]
+
+
+def test_analyze_file_tracking_validationcommands_tests_not_in_untracked(
+    tmp_path: Path,
+):
+    """Test that test files from validationCommands do NOT appear in untracked_tests."""
+    # Create test files
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_unit.py").write_text("# unit test")
+    (tmp_path / "tests" / "test_integration.py").write_text("# integration test")
+
+    manifest_chain = [
+        {
+            "goal": "Create app",
+            "creatableFiles": ["app.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "app.py",
+                "contains": [{"type": "function", "name": "main"}],
+            },
+            "validationCommands": [
+                ["pytest", "tests/test_unit.py", "-v"],
+                ["pytest", "tests/test_integration.py", "-v"],
+            ],
+        }
+    ]
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    # Both test files should be tracked, NOT in untracked_tests
+    assert "tests/test_unit.py" not in analysis["untracked_tests"]
+    assert "tests/test_integration.py" not in analysis["untracked_tests"]
+    assert "tests/test_unit.py" in analysis["tracked"]
+    assert "tests/test_integration.py" in analysis["tracked"]
+
+
+def test_analyze_file_tracking_mixed_tracked_and_untracked_tests(tmp_path: Path):
+    """Test that only tests NOT in manifests appear in untracked_tests."""
+    # Create test files
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_tracked.py").write_text(
+        "# tracked via validationCommand"
+    )
+    (tmp_path / "tests" / "test_untracked.py").write_text("# not in any manifest")
+
+    manifest_chain = [
+        {
+            "goal": "Create module",
+            "creatableFiles": ["module.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "module.py",
+                "contains": [{"type": "function", "name": "func"}],
+            },
+            "validationCommand": ["pytest", "tests/test_tracked.py", "-v"],
+        }
+    ]
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    # test_tracked.py should be tracked (from validationCommand)
+    assert "tests/test_tracked.py" not in analysis["untracked_tests"]
+    assert "tests/test_tracked.py" in analysis["tracked"]
+
+    # test_untracked.py should be in untracked_tests (not in any manifest)
+    assert "tests/test_untracked.py" in analysis["untracked_tests"]
+
+
+def test_analyze_file_tracking_test_in_readonly_and_validationcommand(tmp_path: Path):
+    """Test that test files in both readonlyFiles and validationCommand are tracked."""
+    # Create test file
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_module.py").write_text("# test file")
+
+    manifest_chain = [
+        {
+            "goal": "Create module",
+            "creatableFiles": ["module.py"],
+            "readonlyFiles": ["tests/test_module.py"],  # Also in readonlyFiles
+            "expectedArtifacts": {
+                "file": "module.py",
+                "contains": [{"type": "function", "name": "func"}],
+            },
+            "validationCommand": ["pytest", "tests/test_module.py", "-v"],
+        }
+    ]
+
+    analysis = analyze_file_tracking(manifest_chain, str(tmp_path))
+
+    # Test file should be tracked, not in untracked_tests
+    assert "tests/test_module.py" not in analysis["untracked_tests"]
+    assert "tests/test_module.py" in analysis["tracked"]
+
+
+# ============================================================================
+# Test various pytest command formats are handled correctly
+# ============================================================================
+
+
+def test_collect_tracked_files_multiple_test_files_in_command():
+    """Test tracking multiple test files from a single validationCommand."""
+    manifest_chain = [
+        {
+            "goal": "Create feature",
+            "creatableFiles": ["feature.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "feature.py",
+                "contains": [{"type": "function", "name": "run"}],
+            },
+            "validationCommand": [
+                "pytest",
+                "tests/test_a.py",
+                "tests/test_b.py",
+                "-v",
+            ],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Both test files should be tracked
+    assert "tests/test_a.py" in tracked
+    assert "tests/test_b.py" in tracked
+
+
+def test_collect_tracked_files_ignores_pytest_flags():
+    """Test that pytest flags are not mistakenly treated as test files."""
+    manifest_chain = [
+        {
+            "goal": "Create feature",
+            "creatableFiles": ["feature.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "feature.py",
+                "contains": [{"type": "function", "name": "run"}],
+            },
+            "validationCommand": [
+                "pytest",
+                "tests/test_feature.py",
+                "-v",
+                "--cov",
+                "src",
+                "--tb=short",
+            ],
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Only the actual test file should be tracked
+    assert "tests/test_feature.py" in tracked
+    # Flags should not be treated as files
+    assert "-v" not in tracked
+    assert "--cov" not in tracked
+    assert "src" not in tracked  # This is a cov argument, not a test file
+
+
+def test_collect_tracked_files_no_validationcommand():
+    """Test that manifests without validationCommand are handled gracefully."""
+    manifest_chain = [
+        {
+            "goal": "Create utility",
+            "creatableFiles": ["utility.py"],
+            "readonlyFiles": [],
+            "expectedArtifacts": {
+                "file": "utility.py",
+                "contains": [{"type": "function", "name": "help"}],
+            },
+            # No validationCommand
+        }
+    ]
+
+    tracked = collect_tracked_files(manifest_chain)
+
+    # Should still work, only creatableFiles tracked
+    assert "utility.py" in tracked
+    # No test files should be extracted (none specified)
+    test_files = [f for f in tracked.keys() if f.startswith("tests/")]
+    assert len(test_files) == 0


### PR DESCRIPTION
### **User description**
## Summary

- Fix false positives in "UNTRACKED TEST FILES" validation output
- Test files referenced in `validationCommand` or `validationCommands` are now properly tracked
- Reduces untracked test file count from 73 to 7

## Changes

- Extended `collect_tracked_files()` in `file_tracker.py` to extract test files from validation commands
- Uses existing `normalize_validation_commands()` and `_extract_from_single_command()` utilities (no code duplication)
- Added 12 behavioral tests covering various pytest command formats

## Test plan

- [x] All 12 task-146 tests pass
- [x] All 3812 pytest tests pass
- [x] All 137 MAID manifests validate
- [x] Type checking passes
- [x] Linting passes


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Extract test files from validationCommand/validationCommands fields

- Prevent false positives in untracked test files validation output

- Reuse existing utilities to avoid code duplication

- Add 12 comprehensive behavioral tests for validation command parsing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validationCommand/validationCommands"] -->|normalize_validation_commands| B["Normalized commands"]
  B -->|_extract_from_single_command| C["Extracted test files"]
  C -->|_is_test_file filter| D["Valid test files"]
  D -->|collect_tracked_files| E["Tracked files dict"]
  E -->|analyze_file_tracking| F["No false positives in untracked_tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_tracker.py</strong><dd><code>Extract test files from validation commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

maid_runner/validators/file_tracker.py

<ul><li>Import <code>normalize_validation_commands</code> and <code>_extract_from_single_command</code> <br>utilities<br> <li> Extract test files from <code>validationCommand</code> and <code>validationCommands</code> <br>fields in <code>collect_tracked_files()</code><br> <li> Filter extracted paths using <code>_is_test_file()</code> to avoid tracking pytest <br>options<br> <li> Add extracted test files to tracked_files dictionary with proper <br>manifest tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/116/files#diff-7cc2f914825ee37de0ed92a337fb90db941a90bc879f35b144f46cf989878d8a">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_146_track_validationcommand_test_files.py</strong><dd><code>Behavioral tests for validation command test file tracking</code></dd></summary>
<hr>

tests/validators/test_task_146_track_validationcommand_test_files.py

<ul><li>Add 12 behavioral tests for tracking test files from <br>validationCommand/validationCommands<br> <li> Test single string commands, node ID formats, and uv run prefixes<br> <li> Verify test files are not reported as untracked when in validation <br>commands<br> <li> Test handling of multiple test files and pytest flags in commands<br> <li> Test graceful handling of manifests without validation commands</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/116/files#diff-b289dc9ceb6cc18444f5dff0b571ba65abceae860621ff7aeeecbcc65d77f7fb">+346/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-146-track-validationcommand-test-files.manifest.json</strong><dd><code>Manifest for validation command test extraction task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/task-146-track-validationcommand-test-files.manifest.json

<ul><li>Create manifest for task-146 fix implementation<br> <li> Declare editable file as <code>maid_runner/validators/file_tracker.py</code><br> <li> Reference readonly dependencies on test extraction and existing test <br>modules<br> <li> Define validation command to run new test suite</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/maid-runner/pull/116/files#diff-c2407e270c6f870b4e2aea4b6f878fa5d34b65874ef82b730f795630b49979cc">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

